### PR TITLE
Fix controller namespaces for arm and neck bringup

### DIFF
--- a/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
+++ b/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
@@ -1,25 +1,29 @@
 <launch>
     <arg name="robot_type" default="dm" doc="Robot type: [yks]"/>
-    
-    <!-- <param name="legged_robot_description" command="$(find xacro)/xacro $(find legged_dm_description)/urdf/dm.urdf -->
-    <param name="rightarm/legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm.urdf
-        robot_type:=$(arg robot_type) "/>
-    <!-- <param name="legged_robot_description" command="$(find wanren_arm)/urdf/wanren_arm.urdf"/> -->
-    <param name="rightarm/manual_topic_override" value="true"/>
-    <param name="rightarm/manual_cmd_timeout" value="0.2"/>
-    <rosparam file="$(find legged_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+    <arg name="ns" default="" doc="Namespace for the hardware node"/>
 
-    <node name="legged_dm_hw" pkg="legged_dm_hw" type="legged_dm_hw" respawn="false" clear_params="true" output="screen">
-    </node>
-    
-  <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen" 	respawn="true" respawn_delay="0.002" >
-        <param name="yesense_port"      type="string" value="/dev/ttyACM1"/>
-        <param name="yesense_baudrate"  type="int"    value="460800"/>
-    </node>-->
-	
-   <!--<node pkg="dm_imu" type="dm_imu_node" name="dm_imu_node" required="true" output = "screen" >
-    <param name="port"  type="string" value="/dev/ttyACM1" />
-    <param name="baud"  type="int"    value="921600"/>
-  </node>-->
-  	
+    <group ns="$(arg ns)">
+        <!-- <param name="legged_robot_description" command="$(find xacro)/xacro $(find legged_dm_description)/urdf/dm.urdf -->
+        <param name="legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm.urdf
+            robot_type:=$(arg robot_type) "/>
+        <!-- <param name="legged_robot_description" command="$(find wanren_arm)/urdf/wanren_arm.urdf"/> -->
+        <param name="manual_topic_override" value="true"/>
+        <param name="manual_cmd_timeout" value="0.2"/>
+        <rosparam file="$(find legged_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+
+        <node name="legged_dm_hw" pkg="legged_dm_hw" type="legged_dm_hw" respawn="false" clear_params="true" output="screen">
+        </node>
+
+      <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen"   respawn="true" respawn_delay="0.002" >
+            <param name="yesense_port"      type="string" value="/dev/ttyACM1"/>
+            <param name="yesense_baudrate"  type="int"    value="460800"/>
+        </node>-->
+
+       <!--<node pkg="dm_imu" type="dm_imu_node" name="dm_imu_node" required="true" output = "screen" >
+        <param name="port"  type="string" value="/dev/ttyACM1" />
+        <param name="baud"  type="int"    value="921600"/>
+      </node>-->
+
+    </group>
+
 </launch>

--- a/legged_examples/neck_dm_hw/launch/neck_dm_hw.launch
+++ b/legged_examples/neck_dm_hw/launch/neck_dm_hw.launch
@@ -1,24 +1,28 @@
 <launch>
     <arg name="robot_type" default="dm" doc="Robot type: [yks]"/>
-    
-    <!-- <param name="legged_robot_description" command="$(find xacro)/xacro $(find legged_dm_description)/urdf/dm.urdf -->
-    <param name="neck/legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm_neck.urdf
-        robot_type:=$(arg robot_type) "/>
-    <param name="neck/manual_topic_override" value="true"/>
-    <param name="neck/manual_cmd_timeout" value="0.2"/>
-    <rosparam file="$(find neck_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+    <arg name="ns" default="" doc="Namespace for the hardware node"/>
 
-    <node name="neck_dm_hw" pkg="neck_dm_hw" type="neck_dm_hw" respawn="false" clear_params="true" output="screen">
-    </node>
-    
-  <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen" 	respawn="true" respawn_delay="0.002" >
-        <param name="yesense_port"      type="string" value="/dev/ttyACM1"/>
-        <param name="yesense_baudrate"  type="int"    value="460800"/>
-    </node>-->
-	
-   <!--<node pkg="dm_imu" type="dm_imu_node" name="dm_imu_node" required="true" output = "screen" >
-    <param name="port"  type="string" value="/dev/ttyACM1" />
-    <param name="baud"  type="int"    value="921600"/>
-  </node>-->
-  	
+    <group ns="$(arg ns)">
+        <!-- <param name="legged_robot_description" command="$(find xacro)/xacro $(find legged_dm_description)/urdf/dm.urdf -->
+        <param name="legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm_neck.urdf
+            robot_type:=$(arg robot_type) "/>
+        <param name="manual_topic_override" value="true"/>
+        <param name="manual_cmd_timeout" value="0.2"/>
+        <rosparam file="$(find neck_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+
+        <node name="neck_dm_hw" pkg="neck_dm_hw" type="neck_dm_hw" respawn="false" clear_params="true" output="screen">
+        </node>
+
+      <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen"   respawn="true" respawn_delay="0.002" >
+            <param name="yesense_port"      type="string" value="/dev/ttyACM1"/>
+            <param name="yesense_baudrate"  type="int"    value="460800"/>
+        </node>-->
+
+       <!--<node pkg="dm_imu" type="dm_imu_node" name="dm_imu_node" required="true" output = "screen" >
+        <param name="port"  type="string" value="/dev/ttyACM1" />
+        <param name="baud"  type="int"    value="921600"/>
+      </node>-->
+
+    </group>
+
 </launch>

--- a/simple_hybrid_joint_controller/launch/bringup_real.launch
+++ b/simple_hybrid_joint_controller/launch/bringup_real.launch
@@ -1,30 +1,34 @@
 <launch>
-  <!-- 串口参数写到根空间，供 dmbot_serial::robot 使用（若你用 DmHW+stm32 串口） -->
+  <!-- 为右臂硬件设置私有串口参数 -->
   <arg name="port" default="/dev/mcu_rightarm"/>
   <arg name="baud" default="921600"/>
-  <param name="/port" value="$(arg port)"/>
-  <param name="/baud" value="$(arg baud)"/>
+  <param name="rightarm/port" value="$(arg port)"/>
+  <param name="rightarm/baud" value="$(arg baud)"/>
 
   <!-- 硬件 bringup（会带 controller_manager） -->
-  <include file="$(find legged_dm_hw)/launch/legged_dm_hw.launch"/>
+  <include file="$(find legged_dm_hw)/launch/legged_dm_hw.launch">
+    <arg name="ns" value="rightarm"/>
+  </include>
 
   <!-- 必须：URDF 里已经有这14个 joints -->
-  <rosparam param="rightarm/joint_state_controller">
-    type: joint_state_controller/JointStateController
-    publish_rate: 100
-  </rosparam>
+  <group ns="rightarm">
+    <rosparam param="joint_state_controller">
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
+    </rosparam>
 
-  <rosparam param="rightarm/all_joints_hjc">
-    type: simple_hjc/AllJointsHybridController
-    joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
-             'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
-    default_kp: 0.0
-    default_kd: 0.0
-    default_vel: 0.0
-    default_ff:  0.0
-  </rosparam>
+    <rosparam param="all_joints_hjc">
+      type: simple_hjc/AllJointsHybridController
+      joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
+               'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
+      default_kp: 0.0
+      default_kd: 0.0
+      default_vel: 0.0
+      default_ff:  0.0
+    </rosparam>
 
-  <node pkg="controller_manager" type="spawner" name="spawner_rightarm"
-        output="screen"
-        args="rightarm/joint_state_controller rightarm/all_joints_hjc"/>
+    <node pkg="controller_manager" type="spawner" name="spawner_rightarm"
+          output="screen"
+          args="joint_state_controller all_joints_hjc"/>
+  </group>
 </launch>

--- a/simple_hybrid_joint_controller_neck/launch/bringup_real.launch
+++ b/simple_hybrid_joint_controller_neck/launch/bringup_real.launch
@@ -1,33 +1,37 @@
 <launch>
-  <!-- 串口参数写到根空间，供 dmbot_serial::robot 使用（若你用 DmHW+stm32 串口） -->
+  <!-- 为颈部硬件设置私有串口参数 -->
   <arg name="port" default="/dev/mcu_neck"/>
   <arg name="baud" default="921600"/>
-  <param name="/port" value="$(arg port)"/>
-  <param name="/baud" value="$(arg baud)"/>
+  <param name="neck/port" value="$(arg port)"/>
+  <param name="neck/baud" value="$(arg baud)"/>
 
   <!-- 硬件 bringup（会带 controller_manager） -->
-  <include file="$(find neck_dm_hw)/launch/neck_dm_hw.launch"/>
+  <include file="$(find neck_dm_hw)/launch/neck_dm_hw.launch">
+    <arg name="ns" value="neck"/>
+  </include>
 
   <!-- 必须：URDF 里已经有这14个 joints -->
-  <rosparam param="neck/joint_state_controller">
-    type: joint_state_controller/JointStateController
-    publish_rate: 100
-  </rosparam>
-
-  <rosparam param="neck/all_joints_hjc_neck">
-      type: simple_hjc/AllJointsHybridController
-      joints: ['neck_l1_joint','neck_l2_joint','neck_l3_joint',
-               'neck_l4_joint','neck_l5_joint','neck_l6_joint','neck_l7_joint',
-               'neck_r1_joint','neck_r2_joint','neck_r3_joint',
-               'neck_r4_joint','neck_r5_joint','neck_r6_joint','neck_r7_joint']
-      default_kp: 0.0
-      default_kd: 0.0
-      default_vel: 0.0
-      default_ff:  0.0
+  <group ns="neck">
+    <rosparam param="joint_state_controller">
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
     </rosparam>
 
-  <node pkg="controller_manager" type="spawner" name="spawner_neck"
-        output="screen"
-        args="neck/joint_state_controller neck/all_joints_hjc_neck"/>
+    <rosparam param="all_joints_hjc_neck">
+        type: simple_hjc/AllJointsHybridController
+        joints: ['neck_l1_joint','neck_l2_joint','neck_l3_joint',
+                 'neck_l4_joint','neck_l5_joint','neck_l6_joint','neck_l7_joint',
+                 'neck_r1_joint','neck_r2_joint','neck_r3_joint',
+                 'neck_r4_joint','neck_r5_joint','neck_r6_joint','neck_r7_joint']
+        default_kp: 0.0
+        default_kd: 0.0
+        default_vel: 0.0
+        default_ff:  0.0
+      </rosparam>
+
+    <node pkg="controller_manager" type="spawner" name="spawner_neck"
+          output="screen"
+          args="joint_state_controller all_joints_hjc_neck"/>
+  </group>
 </launch>
 


### PR DESCRIPTION
## Summary
- add namespace support to the legged and neck hardware launch files so each instance can be isolated
- scope the right arm bringup parameters, controller configuration, and spawner under the rightarm namespace
- scope the neck bringup parameters, controller configuration, and spawner under the neck namespace

## Testing
- catkin_make *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d52bae58748323a95be2c253f9349c