### PR TITLE
Fix missing namespace brace in LeggedHW

### DIFF
--- a/legged_hw/src/LeggedHW.cpp
+++ b/legged_hw/src/LeggedHW.cpp
@@ -63,4 +63,4 @@ bool LeggedHW::loadUrdf(ros::NodeHandle& rootNh)
 //   return !urdfString.empty() && urdfModel_->initString(urdfString);
 // }
 
-// }  // namespace legged
+}  // namespace legged


### PR DESCRIPTION
## Summary
- add the missing closing brace for the legged namespace in LeggedHW.cpp to restore a valid translation unit

## Testing
- not run (catkin command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d53900f56c83239dc1370050e34702