### PR TITLE
Fix URDF parameter namespace for legged_dm_hw

### DIFF
--- a/src/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
+++ b/src/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
@@ -4,7 +4,7 @@
 
     <group ns="$(arg ns)">
         <!-- <param name="legged_robot_description" command="$(find xacro)/xacro $(find legged_dm_description)/urdf/dm.urdf -->
-        <param name="legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm.urdf
+        <param name="legged_dm_hw/legged_robot_description" command="$(find xacro)/xacro $(find wanren_arm)/urdf/wanren_arm.urdf
             robot_type:=$(arg robot_type) "/>
         <!-- <param name="legged_robot_description" command="$(find wanren_arm)/urdf/wanren_arm.urdf"/> -->
         <param name="manual_topic_override" value="true"/>


### PR DESCRIPTION
## Summary
- scope the URDF parameter under the legged_dm_hw private namespace so the hardware node can load it correctly

## Testing
- not run (launch-only change)


------
https://chatgpt.com/codex/tasks/task_b_68d53fa1ae188323afe9cdf37fa52f6a