### PR TITLE
Fix URDF lookup fallback for neck hardware

### DIFF
--- a/src/legged_hw/src/LeggedHW.cpp
+++ b/src/legged_hw/src/LeggedHW.cpp
@@ -44,8 +44,11 @@ bool LeggedHW::loadUrdf(ros::NodeHandle& rootNh)
   ros::NodeHandle nh_private("~");
   if (!nh_private.getParam("legged_robot_description", urdfString))
   {
-    ROS_ERROR("URDF not found in ns: %s", nh_private.getNamespace().c_str());
-    return false;
+    if (!rootNh.getParam("legged_robot_description", urdfString))
+    {
+      ROS_ERROR("URDF not found in ns: %s", nh_private.getNamespace().c_str());
+      return false;
+    }
   }
 
   return urdfModel_->initString(urdfString);


### PR DESCRIPTION
## Summary
- allow the legged hardware interface to load the URDF from either the node's private namespace or the enclosing namespace

## Testing
- catkin build legged_hw *(fails: command not found)*
- catkin_make *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d5419388688323ad2f385d3449edb3