### PR TITLE
Add configurable motor ID mapping for neck hardware

### DIFF
--- a/src/READMEE-START.md
+++ b/src/READMEE-START.md
@@ -48,8 +48,13 @@ rostopic pub rightarm/all_joints_hjc/command_one std_msgs/Float64MultiArray "dat
 
 rostopic pub neck/all_joints_hjc_neck/command_one std_msgs/Float64MultiArray "data: [10, 1.0, 0.0, 2.0, 1.0, 0.0]"
 
+# 自定义电机 ID 映射（示例：仅启用 9 号电机控制第 10 个关节，其余禁用）
+rosparam set /neck/motor_id_map "[-1, -1, -1, -1, -1, -1, -1, -1, -1, 9, -1, -1, -1, -1]"
+
+# 注意：列表长度必须为 14，对应 14 个关节；值为 -1 表示忽略该关节。
+
 # 高级控制
-# MoveJ 
+# MoveJ
 # all motor input:position Kp=10 Kd=1 ff=0 vel=0
 rostopic pub /all_joints_hjc/command_moveJ std_msgs/Float64MultiArray "data: [0.0, 0.0, 0.0, 0.5, 1.0, 1.0, 1.0]"
 

--- a/src/legged_examples/leftarm_dm_hw/include/neck_dm_hw/DmHW.h
+++ b/src/legged_examples/leftarm_dm_hw/include/neck_dm_hw/DmHW.h
@@ -32,6 +32,8 @@ struct DmImuData
   double linear_acc_cov[9];
 };
 
+static constexpr int kInvalidMotor = -1;
+
 class DmHW : public LeggedHW
 {
 public:
@@ -58,6 +60,9 @@ private:
   void hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void emgCb(const std_msgs::Float32::ConstPtr& msg);
 
+  // 关节到电机 ID 映射
+  void loadMotorIdMap(const ros::NodeHandle& robot_hw_nh);
+
   // 发布/订阅器
   ros::Publisher cmd_pos_pub_, cmd_vel_pub_, cmd_ff_pub_, read_pos_pub_, read_vel_pub_, read_ff_pub_;
   ros::Subscriber odom_sub_;
@@ -70,9 +75,11 @@ private:
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
 
+  std::array<int, NUM_JOINTS> motorIdMap_{};
+
   // 下发缓冲（电机方向映射）
   DmMotorData dmSendcmd_[NUM_JOINTS];
-  const std::vector<int> directionMotor_{ 
+  const std::vector<int> directionMotor_{
     1, 1, -1, 1, 1,   -1, 1,    // 左腿 0..6
     -1, -1, -1, 1, 1, -1, 1     // 右腿 7..13 例子，按需改
   };

--- a/src/legged_examples/leftarm_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/leftarm_dm_hw/src/DmHW.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 namespace legged
 {
@@ -37,6 +38,8 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
 
   robot_hw_nh.getParam("power_limit", powerLimit_);
 
+  loadMotorIdMap(robot_hw_nh);
+
   // 注册关节、IMU句柄
   setupJoints();
   setupImu();
@@ -62,7 +65,16 @@ void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
   double pos, vel, tau;
   for (int i=0; i< NUM_JOINTS; ++i)
   {
-    motorsInterface->get_motor_data(pos, vel, tau, i);
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    {
+      jointData_[i].pos_ = 0.0;
+      jointData_[i].vel_ = 0.0;
+      jointData_[i].tau_ = 0.0;
+      continue;
+    }
+
+    motorsInterface->get_motor_data(pos, vel, tau, motor_idx);
     jointData_[i].pos_ = pos * directionMotor_[i];
     jointData_[i].vel_ = vel * directionMotor_[i];
     jointData_[i].tau_ = tau * directionMotor_[i];
@@ -116,22 +128,48 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
       ff      = jointData_[i].ff_;
     }
 
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    {
+      ROS_WARN_THROTTLE(5.0,
+        "[LeftArm] Joint %d disabled by motor_id_map, skip command.", i);
+      dmSendcmd_[i].pos_des_ = 0.0;
+      dmSendcmd_[i].vel_des_ = 0.0;
+      dmSendcmd_[i].kp_      = 0.0;
+      dmSendcmd_[i].kd_      = 0.0;
+      dmSendcmd_[i].ff_      = 0.0;
+      continue;
+    }
+
+    ROS_INFO_THROTTLE(1.0,
+      "[LeftArm] Pre-map Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f (manual=%d)",
+      i, motor_idx, pos_des, vel_des, kp, kd, ff, use_manual);
+
     // 关节→电机 方向映射
     dmSendcmd_[i].pos_des_ = pos_des * directionMotor_[i];
     dmSendcmd_[i].vel_des_ = vel_des * directionMotor_[i];
     dmSendcmd_[i].kp_      = kp;
     dmSendcmd_[i].kd_      = kd;
     dmSendcmd_[i].ff_      = ff * directionMotor_[i];
+
+    ROS_INFO_THROTTLE(1.0,
+      "[LeftArm] Mapped  Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f",
+      i, motor_idx, dmSendcmd_[i].pos_des_, dmSendcmd_[i].vel_des_,
+      dmSendcmd_[i].kp_, dmSendcmd_[i].kd_, dmSendcmd_[i].ff_);
   }
 
   // 写入下位机
   for (int i = 0; i < NUM_JOINTS; ++i)
   {
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+      continue;
+
     motorsInterface->fresh_cmd_motor_data(dmSendcmd_[i].pos_des_,
                                           dmSendcmd_[i].vel_des_,
                                           dmSendcmd_[i].ff_,
                                           dmSendcmd_[i].kp_,
-                                          dmSendcmd_[i].kd_, i);
+                                          dmSendcmd_[i].kd_, motor_idx);
   }
   motorsInterface->send_motor_data();
 
@@ -140,6 +178,66 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
   a.data.resize(NUM_JOINTS);
   for (int i=0;i<NUM_JOINTS;++i) a.data[i] = dmSendcmd_[i].pos_des_;
   cmd_pos_pub_.publish(a);
+}
+
+void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
+{
+  for (int i = 0; i < NUM_JOINTS; ++i)
+    motorIdMap_[i] = i;
+
+  std::vector<int> motor_ids;
+  if (!robot_hw_nh.getParam("motor_id_map", motor_ids))
+  {
+    ROS_INFO("[DmHW] '~motor_id_map' not set, using default 0..%d", NUM_JOINTS - 1);
+    return;
+  }
+
+  if (motor_ids.size() != NUM_JOINTS)
+  {
+    ROS_WARN("[DmHW] '~motor_id_map' size=%zu, expected %d. Keep default mapping.",
+             motor_ids.size(), NUM_JOINTS);
+    return;
+  }
+
+  std::array<bool, NUM_JOINTS> used{};
+  for (size_t i = 0; i < motor_ids.size(); ++i)
+  {
+    int id = motor_ids[i];
+    if (id == kInvalidMotor)
+    {
+      motorIdMap_[i] = kInvalidMotor;
+      continue;
+    }
+
+    if (id < 0 || id >= NUM_JOINTS)
+    {
+      ROS_WARN("[DmHW] motor_id_map[%zu]=%d out of range [0,%d]. Revert to default mapping.",
+               i, id, NUM_JOINTS - 1);
+      for (int j = 0; j < NUM_JOINTS; ++j)
+        motorIdMap_[j] = j;
+      return;
+    }
+
+    if (used[id])
+    {
+      ROS_WARN("[DmHW] motor_id_map contains duplicate id %d. Revert to default mapping.", id);
+      for (int j = 0; j < NUM_JOINTS; ++j)
+        motorIdMap_[j] = j;
+      return;
+    }
+
+    used[id] = true;
+    motorIdMap_[i] = id;
+  }
+
+  std::ostringstream oss;
+  for (int i = 0; i < NUM_JOINTS; ++i)
+  {
+    if (i)
+      oss << ", ";
+    oss << motorIdMap_[i];
+  }
+  ROS_INFO_STREAM("[DmHW] Using motor_id_map: [" << oss.str() << "]");
 }
 
 bool DmHW::setupJoints()

--- a/src/legged_examples/neck_dm_hw/config/dm.yaml
+++ b/src/legged_examples/neck_dm_hw/config/dm.yaml
@@ -4,4 +4,6 @@ neck_dm_hw:
   thread_priority: 95
   power_limit: 6
   contact_threshold: 200
+  # 关节索引 -> 实际电机 CAN ID 映射（-1 表示禁用该关节）。默认保持 0..13 顺序，可按需修改。
+  motor_id_map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
 

--- a/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
+++ b/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
@@ -32,6 +32,8 @@ struct DmImuData
   double linear_acc_cov[9];
 };
 
+static constexpr int kInvalidMotor = -1;
+
 class DmHW : public LeggedHW
 {
 public:
@@ -58,6 +60,9 @@ private:
   void hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void emgCb(const std_msgs::Float32::ConstPtr& msg);
 
+  // 关节到电机 ID 映射
+  void loadMotorIdMap(const ros::NodeHandle& robot_hw_nh);
+
   // 发布/订阅器
   ros::Publisher cmd_pos_pub_, cmd_vel_pub_, cmd_ff_pub_, read_pos_pub_, read_vel_pub_, read_ff_pub_;
   ros::Subscriber odom_sub_;
@@ -70,9 +75,11 @@ private:
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
 
+  std::array<int, NUM_JOINTS> motorIdMap_{};
+
   // 下发缓冲（电机方向映射）
   DmMotorData dmSendcmd_[NUM_JOINTS];
-  const std::vector<int> directionMotor_{ 
+  const std::vector<int> directionMotor_{
     1, 1, -1, 1, 1,   -1, 1,    // 左腿 0..6
     -1, -1, -1, 1, 1, -1, 1     // 右腿 7..13 例子，按需改
   };

--- a/src/legged_examples/neck_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/neck_dm_hw/src/DmHW.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <sstream>
 
 namespace legged
 {
@@ -37,6 +38,8 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
 
   robot_hw_nh.getParam("power_limit", powerLimit_);
 
+  loadMotorIdMap(robot_hw_nh);
+
   // 注册关节、IMU句柄
   setupJoints();
   setupImu();
@@ -62,7 +65,16 @@ void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
   double pos, vel, tau;
   for (int i=0; i< NUM_JOINTS; ++i)
   {
-    motorsInterface->get_motor_data(pos, vel, tau, i);
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    {
+      jointData_[i].pos_ = 0.0;
+      jointData_[i].vel_ = 0.0;
+      jointData_[i].tau_ = 0.0;
+      continue;
+    }
+
+    motorsInterface->get_motor_data(pos, vel, tau, motor_idx);
     jointData_[i].pos_ = pos * directionMotor_[i];
     jointData_[i].vel_ = vel * directionMotor_[i];
     jointData_[i].tau_ = tau * directionMotor_[i];
@@ -116,10 +128,23 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
       ff      = jointData_[i].ff_;
     }
 
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    {
+      ROS_WARN_THROTTLE(5.0,
+        "[Neck] Joint %d disabled by motor_id_map, skip command.", i);
+      dmSendcmd_[i].pos_des_ = 0.0;
+      dmSendcmd_[i].vel_des_ = 0.0;
+      dmSendcmd_[i].kp_      = 0.0;
+      dmSendcmd_[i].kd_      = 0.0;
+      dmSendcmd_[i].ff_      = 0.0;
+      continue;
+    }
+
     // ⭐ 在这里加日志，打印 controller 写进来的数据
     ROS_INFO_THROTTLE(1.0,
-      "[Neck] Pre-map Joint[%d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f (manual=%d)",
-      i, pos_des, vel_des, kp, kd, ff, use_manual);
+      "[Neck] Pre-map Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f (manual=%d)",
+      i, motor_idx, pos_des, vel_des, kp, kd, ff, use_manual);
 
     // 关节→电机 方向映射
     dmSendcmd_[i].pos_des_ = pos_des * directionMotor_[i];
@@ -130,21 +155,85 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
 
     // ⭐ 再加一层，确认映射后的数据
     ROS_INFO_THROTTLE(1.0,
-      "[Neck] Mapped  Joint[%d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f",
-      i, dmSendcmd_[i].pos_des_, dmSendcmd_[i].vel_des_, dmSendcmd_[i].kp_,
+      "[Neck] Mapped  Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f",
+      i, motor_idx, dmSendcmd_[i].pos_des_, dmSendcmd_[i].vel_des_, dmSendcmd_[i].kp_,
       dmSendcmd_[i].kd_, dmSendcmd_[i].ff_);
   }
 
   // 写入下位机
   for (int i = 0; i < NUM_JOINTS; ++i)
   {
+    const int motor_idx = motorIdMap_[i];
+    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+      continue;
+
     motorsInterface->fresh_cmd_motor_data(dmSendcmd_[i].pos_des_,
                                           dmSendcmd_[i].vel_des_,
                                           dmSendcmd_[i].ff_,
                                           dmSendcmd_[i].kp_,
-                                          dmSendcmd_[i].kd_, i);
+                                          dmSendcmd_[i].kd_, motor_idx);
   }
   motorsInterface->send_motor_data();
+}
+
+void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
+{
+  for (int i = 0; i < NUM_JOINTS; ++i)
+    motorIdMap_[i] = i;
+
+  std::vector<int> motor_ids;
+  if (!robot_hw_nh.getParam("motor_id_map", motor_ids))
+  {
+    ROS_INFO("[DmHW] '~motor_id_map' not set, using default 0..%d", NUM_JOINTS - 1);
+    return;
+  }
+
+  if (motor_ids.size() != NUM_JOINTS)
+  {
+    ROS_WARN("[DmHW] '~motor_id_map' size=%zu, expected %d. Keep default mapping.",
+             motor_ids.size(), NUM_JOINTS);
+    return;
+  }
+
+  std::array<bool, NUM_JOINTS> used{};
+  for (size_t i = 0; i < motor_ids.size(); ++i)
+  {
+    int id = motor_ids[i];
+    if (id == kInvalidMotor)
+    {
+      motorIdMap_[i] = kInvalidMotor;
+      continue;
+    }
+
+    if (id < 0 || id >= NUM_JOINTS)
+    {
+      ROS_WARN("[DmHW] motor_id_map[%zu]=%d out of range [0,%d]. Revert to default mapping.",
+               i, id, NUM_JOINTS - 1);
+      for (int j = 0; j < NUM_JOINTS; ++j)
+        motorIdMap_[j] = j;
+      return;
+    }
+
+    if (used[id])
+    {
+      ROS_WARN("[DmHW] motor_id_map contains duplicate id %d. Revert to default mapping.", id);
+      for (int j = 0; j < NUM_JOINTS; ++j)
+        motorIdMap_[j] = j;
+      return;
+    }
+
+    used[id] = true;
+    motorIdMap_[i] = id;
+  }
+
+  std::ostringstream oss;
+  for (int i = 0; i < NUM_JOINTS; ++i)
+  {
+    if (i)
+      oss << ", ";
+    oss << motorIdMap_[i];
+  }
+  ROS_INFO_STREAM("[DmHW] Using motor_id_map: [" << oss.str() << "]");
 }
 
 bool DmHW::setupJoints()


### PR DESCRIPTION
## Summary
- add configurable joint-to-motor mapping support (with skip option) in neck and left arm hardware interfaces
- expose the mapping through the existing neck hardware YAML config and document how to adjust it for specific motors
- extend logging to show real motor indices used when sending commands, easing debugging

## Testing
- `catkin_make` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d544fff8c883238a855751351be68e