### PR TITLE
Fix controller namespace logging

### DIFF
--- a/src/simple_hybrid_joint_controller_neck/include/simple_hybrid_joint_controller_neck/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_neck/include/simple_hybrid_joint_controller_neck/AllJointsHybridController.h
@@ -3,6 +3,7 @@
 #include <std_msgs/Float64MultiArray.h>
 #include <controller_interface/controller.h>
 #include <legged_common/hardware_interface/HybridJointInterface.h>
+#include <string>
 
 namespace simple_hjc {
 
@@ -26,6 +27,9 @@ private:
 
   // 订阅者
   ros::Subscriber sub_same_, sub_pos_all_, sub_matrix_,sub_one_, sub_move_j_;
+
+  // 控制器所在的命名空间标签（用于日志输出）
+  std::string controller_ns_;
 
   void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);

--- a/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
@@ -23,6 +23,13 @@ bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::Node
     joint_names_ = kDefaultJointNames;
     ROS_WARN("param '~joints' not set, using default (%zu)", joint_names_.size());
   }
+  controller_ns_ = nh.getNamespace();
+  if (!controller_ns_.empty() && controller_ns_.front() == '/') {
+    controller_ns_.erase(0, 1);
+  }
+  if (controller_ns_.empty()) {
+    controller_ns_ = "AllJointsHybridController";
+  }
   // joint_names_ = kDefaultJointNames;
   N_ = joint_names_.size();
   if (N_ == 0) {
@@ -73,9 +80,14 @@ void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
   // 把缓存的命令写到 HybridJointHandle
   for (size_t i = 0; i < N_; ++i) {
     handles_[i].setCommand(cmd_[i][0], cmd_[i][1], cmd_[i][2], cmd_[i][3], cmd_[i][4]);
-    ROS_INFO_THROTTLE(1.0, "[Neck] Controller update running, first joint pos_des=%.3f", cmd_[i][0]);
   }
-  
+
+  if (!cmd_.empty()) {
+    ROS_INFO_THROTTLE(1.0,
+                      "[%s] Controller update running, first joint pos_des=%.3f",
+                      controller_ns_.c_str(), cmd_.front()[0]);
+  }
+
 }
 
 void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {


### PR DESCRIPTION
## Summary
- capture the controller namespace from the ROS node handle during initialization
- emit throttled update logs using the captured namespace instead of the hardcoded "Neck" label
- avoid printing the throttled log message once per joint update

## Testing
- `catkin_make` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68d548df3d748323a970b206e72a152e