### PR TITLE
Improve hybrid joint controller naming and default gains

### DIFF
--- a/src/simple_hybrid_joint_controller/include/simple_hybrid_joint_controller/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller/include/simple_hybrid_joint_controller/AllJointsHybridController.h
@@ -14,18 +14,25 @@ public:
   void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
-  std::vector<legged::HybridJointHandle> handles_;
-  std::vector<std::string> joint_names_;
-  size_t N_{0};  // 关节数 = joints.size()
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
 
   // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
-  std::vector<std::array<double,5>> cmd_;
+  std::vector<std::array<double,5>> jointCommandBuffer_;
 
   // 默认参数
-  double default_kp_{100.0}, default_kd_{2.0}, default_vel_{0.0}, default_ff_{0.0};
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
 
   // 订阅者
-  ros::Subscriber sub_same_, sub_pos_all_, sub_matrix_,sub_one_, sub_move_j_;
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
 
   void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);

--- a/src/simple_hybrid_joint_controller/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller/launch/bringup_real.launch
@@ -21,8 +21,8 @@
       type: simple_hjc/AllJointsHybridController
       joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
                'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
-      default_kp: 0.0
-      default_kd: 0.0
+      default_kp: 20.0
+      default_kd: 1.0
       default_vel: 0.0
       default_ff:  0.0
     </rosparam>

--- a/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
@@ -12,102 +12,115 @@ static const std::vector<std::string> kDefaultJointNames = {
 
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
   // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
-  if (!nh.getParam("joints", joint_names_)) {
-    joint_names_ = kDefaultJointNames;
-    ROS_WARN("param '~joints' not set, using default (%zu)", joint_names_.size());
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
   }
-  N_ = joint_names_.size();
-  if (N_ == 0) {
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
     ROS_ERROR("No joints configured.");
     return false;
   }
 
-  nh.param("default_kp", default_kp_, 100.0);
-  nh.param("default_kd", default_kd_, 2.0);
-  nh.param("default_vel", default_vel_, 0.0);
-  nh.param("default_ff",  default_ff_,  0.0);
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
 
-  handles_.reserve(N_);
+  jointHandles_.reserve(jointCount_);
   try {
-    for (const auto& name : joint_names_) {
-      handles_.push_back(hw->getHandle(name));
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
     }
   } catch (const hardware_interface::HardwareInterfaceException& e) {
     ROS_ERROR_STREAM("Get handle failed: " << e.what());
     return false;
   }
 
-  cmd_.assign(N_, {0,0,0,0,0});
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
 
   // 订阅三种命令
-  sub_same_   = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
-  sub_pos_all_= nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
-  sub_matrix_ = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
-  sub_one_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
-  sub_move_j_ = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
 
-  ROS_INFO("AllJointsHybridController ready with %zu joints.", N_);
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
   return true;
 }
 
 void AllJointsHybridController::starting(const ros::Time&) {
   // 将起始目标设为当前位置，避免突跳
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = handles_[i].getPosition(); // pos
-    cmd_[i][1] = default_vel_;              // vel
-    cmd_[i][2] = default_kp_;               // kp
-    cmd_[i][3] = default_kd_;               // kd
-    cmd_[i][4] = default_ff_;               // ff
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
   }
 }
 
 void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
   // 把缓存的命令写到 HybridJointHandle
-  for (size_t i = 0; i < N_; ++i) {
-    handles_[i].setCommand(cmd_[i][0], cmd_[i][1], cmd_[i][2], cmd_[i][3], cmd_[i][4]);
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
   }
 }
 
 void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
-  double pos = cmd_[0][0], vel = default_vel_, kp = default_kp_, kd = default_kd_, ff = default_ff_;
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
   if (msg->data.size() >= 1) pos = msg->data[0];
   if (msg->data.size() >= 2) vel = msg->data[1];
   if (msg->data.size() >= 3) kp  = msg->data[2];
   if (msg->data.size() >= 4) kd  = msg->data[3];
   if (msg->data.size() >= 5) ff  = msg->data[4];
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0]=pos; cmd_[i][1]=vel; cmd_[i][2]=kp; cmd_[i][3]=kd; cmd_[i][4]=ff;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
   }
 }
 
 void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
-  if (msg->data.size() < N_) {
-    ROS_WARN("command_pos_all expects %zu positions, got %zu", N_, msg->data.size());
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = msg->data[i];
-    cmd_[i][1] = default_vel_;
-    cmd_[i][2] = default_kp_;
-    cmd_[i][3] = default_kd_;
-    cmd_[i][4] = default_ff_;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
   }
 }
 
 void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
-  if (msg->data.size() < 5*N_) {
-    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu", 5*N_, N_, msg->data.size());
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
+  for (size_t i = 0; i < jointCount_; ++i) {
     size_t base = i*5;
-    cmd_[i][0]=msg->data[base+0];  // pos
-    cmd_[i][1]=msg->data[base+1];  // vel
-    cmd_[i][2]=msg->data[base+2];  // kp
-    cmd_[i][3]=msg->data[base+3];  // kd
-    cmd_[i][4]=msg->data[base+4];  // ff
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
   }
 }
 // data[0] = 关节索引（int，0..N-1）
@@ -118,8 +131,8 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
     return;
   }
   int idx = static_cast<int>(std::lrint(msg->data[0]));
-  if (idx < 0 || idx >= static_cast<int>(N_)) {
-    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, N_-1);
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
     return;
   }
 
@@ -135,11 +148,11 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
   double ff  = getOrNaN(5);
 
   // 仅对“给了且是有限数”的字段做更新
-  if (std::isfinite(pos)) cmd_[idx][0] = pos;
-  if (std::isfinite(vel)) cmd_[idx][1] = vel;
-  if (std::isfinite(kp )) cmd_[idx][2] = kp;
-  if (std::isfinite(kd )) cmd_[idx][3] = kd;
-  if (std::isfinite(ff )) cmd_[idx][4] = ff;
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
 }
 
 
@@ -151,11 +164,11 @@ void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::Const
 
   // 目标关节位置为从位置 7 到 13（即 idx 7 到 idx 13），假设电机编号从 0 开始
   for (size_t i = 7; i < 14; ++i) {
-    cmd_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
-    cmd_[i][1] = 0.0;  // 速度设为 0
-    cmd_[i][2] = 20.0; // Kp 设置为 20
-    cmd_[i][3] = 1.0;  // Kd 设置为 1
-    cmd_[i][4] = 0.0;  // 力矩为 0
+    jointCommandBuffer_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
+    jointCommandBuffer_[i][1] = 0.0;  // 速度设为 0
+    jointCommandBuffer_[i][2] = 20.0; // Kp 设置为 20
+    jointCommandBuffer_[i][3] = 1.0;  // Kd 设置为 1
+    jointCommandBuffer_[i][4] = 0.0;  // 力矩为 0
   }
 }
 

--- a/src/simple_hybrid_joint_controller_leftarm/include/simple_hybrid_joint_controller_leftarm/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_leftarm/include/simple_hybrid_joint_controller_leftarm/AllJointsHybridController.h
@@ -14,18 +14,25 @@ public:
   void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
-  std::vector<legged::HybridJointHandle> handles_;
-  std::vector<std::string> joint_names_;
-  size_t N_{0};  // 关节数 = joints.size()
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
 
   // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
-  std::vector<std::array<double,5>> cmd_;
+  std::vector<std::array<double,5>> jointCommandBuffer_;
 
   // 默认参数
-  double default_kp_{100.0}, default_kd_{2.0}, default_vel_{0.0}, default_ff_{0.0};
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
 
   // 订阅者
-  ros::Subscriber sub_same_, sub_pos_all_, sub_matrix_,sub_one_, sub_move_j_;
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
 
   void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);

--- a/src/simple_hybrid_joint_controller_leftarm/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_leftarm/launch/bringup_real.launch
@@ -25,8 +25,8 @@
     type: simple_hjc/AllJointsHybridController
     joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
              'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
-    default_kp: 0.0
-    default_kd: 0.0
+    default_kp: 20.0
+    default_kd: 1.0
     default_vel: 0.0
     default_ff:  0.0
   </rosparam>

--- a/src/simple_hybrid_joint_controller_leftarm/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_leftarm/src/AllJointsHybridController.cpp
@@ -12,102 +12,115 @@ static const std::vector<std::string> kDefaultJointNames = {
 
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
   // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
-  if (!nh.getParam("joints", joint_names_)) {
-    joint_names_ = kDefaultJointNames;
-    ROS_WARN("param '~joints' not set, using default (%zu)", joint_names_.size());
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
   }
-  N_ = joint_names_.size();
-  if (N_ == 0) {
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
     ROS_ERROR("No joints configured.");
     return false;
   }
 
-  nh.param("default_kp", default_kp_, 100.0);
-  nh.param("default_kd", default_kd_, 2.0);
-  nh.param("default_vel", default_vel_, 0.0);
-  nh.param("default_ff",  default_ff_,  0.0);
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
 
-  handles_.reserve(N_);
+  jointHandles_.reserve(jointCount_);
   try {
-    for (const auto& name : joint_names_) {
-      handles_.push_back(hw->getHandle(name));
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
     }
   } catch (const hardware_interface::HardwareInterfaceException& e) {
     ROS_ERROR_STREAM("Get handle failed: " << e.what());
     return false;
   }
 
-  cmd_.assign(N_, {0,0,0,0,0});
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
 
   // 订阅三种命令
-  sub_same_   = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
-  sub_pos_all_= nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
-  sub_matrix_ = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
-  sub_one_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
-  sub_move_j_ = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
 
-  ROS_INFO("AllJointsHybridController ready with %zu joints.", N_);
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
   return true;
 }
 
 void AllJointsHybridController::starting(const ros::Time&) {
   // 将起始目标设为当前位置，避免突跳
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = handles_[i].getPosition(); // pos
-    cmd_[i][1] = default_vel_;              // vel
-    cmd_[i][2] = default_kp_;               // kp
-    cmd_[i][3] = default_kd_;               // kd
-    cmd_[i][4] = default_ff_;               // ff
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
   }
 }
 
 void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
   // 把缓存的命令写到 HybridJointHandle
-  for (size_t i = 0; i < N_; ++i) {
-    handles_[i].setCommand(cmd_[i][0], cmd_[i][1], cmd_[i][2], cmd_[i][3], cmd_[i][4]);
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
   }
 }
 
 void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
-  double pos = cmd_[0][0], vel = default_vel_, kp = default_kp_, kd = default_kd_, ff = default_ff_;
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
   if (msg->data.size() >= 1) pos = msg->data[0];
   if (msg->data.size() >= 2) vel = msg->data[1];
   if (msg->data.size() >= 3) kp  = msg->data[2];
   if (msg->data.size() >= 4) kd  = msg->data[3];
   if (msg->data.size() >= 5) ff  = msg->data[4];
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0]=pos; cmd_[i][1]=vel; cmd_[i][2]=kp; cmd_[i][3]=kd; cmd_[i][4]=ff;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
   }
 }
 
 void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
-  if (msg->data.size() < N_) {
-    ROS_WARN("command_pos_all expects %zu positions, got %zu", N_, msg->data.size());
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = msg->data[i];
-    cmd_[i][1] = default_vel_;
-    cmd_[i][2] = default_kp_;
-    cmd_[i][3] = default_kd_;
-    cmd_[i][4] = default_ff_;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
   }
 }
 
 void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
-  if (msg->data.size() < 5*N_) {
-    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu", 5*N_, N_, msg->data.size());
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
+  for (size_t i = 0; i < jointCount_; ++i) {
     size_t base = i*5;
-    cmd_[i][0]=msg->data[base+0];  // pos
-    cmd_[i][1]=msg->data[base+1];  // vel
-    cmd_[i][2]=msg->data[base+2];  // kp
-    cmd_[i][3]=msg->data[base+3];  // kd
-    cmd_[i][4]=msg->data[base+4];  // ff
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
   }
 }
 // data[0] = 关节索引（int，0..N-1）
@@ -118,8 +131,8 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
     return;
   }
   int idx = static_cast<int>(std::lrint(msg->data[0]));
-  if (idx < 0 || idx >= static_cast<int>(N_)) {
-    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, N_-1);
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
     return;
   }
 
@@ -135,11 +148,11 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
   double ff  = getOrNaN(5);
 
   // 仅对“给了且是有限数”的字段做更新
-  if (std::isfinite(pos)) cmd_[idx][0] = pos;
-  if (std::isfinite(vel)) cmd_[idx][1] = vel;
-  if (std::isfinite(kp )) cmd_[idx][2] = kp;
-  if (std::isfinite(kd )) cmd_[idx][3] = kd;
-  if (std::isfinite(ff )) cmd_[idx][4] = ff;
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
 }
 
 
@@ -151,11 +164,11 @@ void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::Const
 
   // 目标关节位置为从位置 7 到 13（即 idx 7 到 idx 13），假设电机编号从 0 开始
   for (size_t i = 7; i < 14; ++i) {
-    cmd_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
-    cmd_[i][1] = 0.0;  // 速度设为 0
-    cmd_[i][2] = 20.0; // Kp 设置为 20
-    cmd_[i][3] = 1.0;  // Kd 设置为 1
-    cmd_[i][4] = 0.0;  // 力矩为 0
+    jointCommandBuffer_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
+    jointCommandBuffer_[i][1] = 0.0;  // 速度设为 0
+    jointCommandBuffer_[i][2] = 20.0; // Kp 设置为 20
+    jointCommandBuffer_[i][3] = 1.0;  // Kd 设置为 1
+    jointCommandBuffer_[i][4] = 0.0;  // 力矩为 0
   }
 }
 

--- a/src/simple_hybrid_joint_controller_neck/include/simple_hybrid_joint_controller_neck/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_neck/include/simple_hybrid_joint_controller_neck/AllJointsHybridController.h
@@ -15,21 +15,28 @@ public:
   void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
-  std::vector<legged::HybridJointHandle> handles_;
-  std::vector<std::string> joint_names_;
-  size_t N_{0};  // 关节数 = joints.size()
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
 
   // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
-  std::vector<std::array<double,5>> cmd_;
+  std::vector<std::array<double,5>> jointCommandBuffer_;
 
   // 默认参数
-  double default_kp_{100.0}, default_kd_{2.0}, default_vel_{0.0}, default_ff_{0.0};
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
 
   // 订阅者
-  ros::Subscriber sub_same_, sub_pos_all_, sub_matrix_,sub_one_, sub_move_j_;
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
 
   // 控制器所在的命名空间标签（用于日志输出）
-  std::string controller_ns_;
+  std::string controllerNamespace_;
 
   void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);

--- a/src/simple_hybrid_joint_controller_neck/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_neck/launch/bringup_real.launch
@@ -23,8 +23,8 @@
                  'neck_l4_joint','neck_l5_joint','neck_l6_joint','neck_l7_joint',
                  'neck_r1_joint','neck_r2_joint','neck_r3_joint',
                  'neck_r4_joint','neck_r5_joint','neck_r6_joint','neck_r7_joint']
-        default_kp: 0.0
-        default_kd: 0.0
+        default_kp: 20.0
+        default_kd: 1.0
         default_vel: 0.0
         default_ff:  0.0
       </rosparam>

--- a/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
@@ -19,117 +19,130 @@ static const std::vector<std::string> kDefaultJointNames = {
 // };
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
   // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
-  if (!nh.getParam("joints", joint_names_)) {
-    joint_names_ = kDefaultJointNames;
-    ROS_WARN("param '~joints' not set, using default (%zu)", joint_names_.size());
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
   }
-  controller_ns_ = nh.getNamespace();
-  if (!controller_ns_.empty() && controller_ns_.front() == '/') {
-    controller_ns_.erase(0, 1);
+  controllerNamespace_ = nh.getNamespace();
+  if (!controllerNamespace_.empty() && controllerNamespace_.front() == '/') {
+    controllerNamespace_.erase(0, 1);
   }
-  if (controller_ns_.empty()) {
-    controller_ns_ = "AllJointsHybridController";
+  if (controllerNamespace_.empty()) {
+    controllerNamespace_ = "AllJointsHybridController";
   }
   // joint_names_ = kDefaultJointNames;
-  N_ = joint_names_.size();
-  if (N_ == 0) {
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
     ROS_ERROR("No joints configured.");
     return false;
   }
 
-  nh.param("default_kp", default_kp_, 100.0);
-  nh.param("default_kd", default_kd_, 2.0);
-  nh.param("default_vel", default_vel_, 0.0);
-  nh.param("default_ff",  default_ff_,  0.0);
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
 
-  handles_.reserve(N_);
+  jointHandles_.reserve(jointCount_);
   try {
-    for (const auto& name : joint_names_) {
-      handles_.push_back(hw->getHandle(name));
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
     }
   } catch (const hardware_interface::HardwareInterfaceException& e) {
     ROS_ERROR_STREAM("Get handle failed: " << e.what());
     return false;
   }
 
-  cmd_.assign(N_, {0,0,0,0,0});
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
 
   // 订阅三种命令
-  sub_same_   = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
-  sub_pos_all_= nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
-  sub_matrix_ = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
-  sub_one_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
-  sub_move_j_ = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
 
-  ROS_INFO("AllJointsHybridController ready with %zu joints.", N_);
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
   return true;
 }
 
 void AllJointsHybridController::starting(const ros::Time&) {
   // 将起始目标设为当前位置，避免突跳
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = handles_[i].getPosition(); // pos
-    cmd_[i][1] = default_vel_;              // vel
-    cmd_[i][2] = default_kp_;               // kp
-    cmd_[i][3] = default_kd_;               // kd
-    cmd_[i][4] = default_ff_;               // ff
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
   }
 }
 
 void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
   // 把缓存的命令写到 HybridJointHandle
-  for (size_t i = 0; i < N_; ++i) {
-    handles_[i].setCommand(cmd_[i][0], cmd_[i][1], cmd_[i][2], cmd_[i][3], cmd_[i][4]);
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
   }
 
-  if (!cmd_.empty()) {
+  if (!jointCommandBuffer_.empty()) {
     ROS_INFO_THROTTLE(1.0,
                       "[%s] Controller update running, first joint pos_des=%.3f",
-                      controller_ns_.c_str(), cmd_.front()[0]);
+                      controllerNamespace_.c_str(), jointCommandBuffer_.front()[0]);
   }
 
 }
 
 void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
-  double pos = cmd_[0][0], vel = default_vel_, kp = default_kp_, kd = default_kd_, ff = default_ff_;
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
   if (msg->data.size() >= 1) pos = msg->data[0];
   if (msg->data.size() >= 2) vel = msg->data[1];
   if (msg->data.size() >= 3) kp  = msg->data[2];
   if (msg->data.size() >= 4) kd  = msg->data[3];
   if (msg->data.size() >= 5) ff  = msg->data[4];
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0]=pos; cmd_[i][1]=vel; cmd_[i][2]=kp; cmd_[i][3]=kd; cmd_[i][4]=ff;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
   }
 }
 
 void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
-  if (msg->data.size() < N_) {
-    ROS_WARN("command_pos_all expects %zu positions, got %zu", N_, msg->data.size());
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
-    cmd_[i][0] = msg->data[i];
-    cmd_[i][1] = default_vel_;
-    cmd_[i][2] = default_kp_;
-    cmd_[i][3] = default_kd_;
-    cmd_[i][4] = default_ff_;
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
   }
 }
 
 void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
   // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
-  if (msg->data.size() < 5*N_) {
-    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu", 5*N_, N_, msg->data.size());
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
     return;
   }
-  for (size_t i = 0; i < N_; ++i) {
+  for (size_t i = 0; i < jointCount_; ++i) {
     size_t base = i*5;
-    cmd_[i][0]=msg->data[base+0];  // pos
-    cmd_[i][1]=msg->data[base+1];  // vel
-    cmd_[i][2]=msg->data[base+2];  // kp
-    cmd_[i][3]=msg->data[base+3];  // kd
-    cmd_[i][4]=msg->data[base+4];  // ff
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
   }
 }
 // data[0] = 关节索引（int，0..N-1）
@@ -140,8 +153,8 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
     return;
   }
   int idx = static_cast<int>(std::lrint(msg->data[0]));
-  if (idx < 0 || idx >= static_cast<int>(N_)) {
-    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, N_-1);
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
     return;
   }
 
@@ -157,11 +170,11 @@ void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPt
   double ff  = getOrNaN(5);
 
   // 仅对“给了且是有限数”的字段做更新
-  if (std::isfinite(pos)) cmd_[idx][0] = pos;
-  if (std::isfinite(vel)) cmd_[idx][1] = vel;
-  if (std::isfinite(kp )) cmd_[idx][2] = kp;
-  if (std::isfinite(kd )) cmd_[idx][3] = kd;
-  if (std::isfinite(ff )) cmd_[idx][4] = ff;
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
 }
 
 
@@ -173,11 +186,11 @@ void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::Const
 
   // 目标关节位置为从位置 7 到 13（即 idx 7 到 idx 13），假设电机编号从 0 开始
   for (size_t i = 7; i < 14; ++i) {
-    cmd_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
-    cmd_[i][1] = 0.0;  // 速度设为 0
-    cmd_[i][2] = 20.0; // Kp 设置为 20
-    cmd_[i][3] = 1.0;  // Kd 设置为 1
-    cmd_[i][4] = 0.0;  // 力矩为 0
+    jointCommandBuffer_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
+    jointCommandBuffer_[i][1] = 0.0;  // 速度设为 0
+    jointCommandBuffer_[i][2] = 20.0; // Kp 设置为 20
+    jointCommandBuffer_[i][3] = 1.0;  // Kd 设置为 1
+    jointCommandBuffer_[i][4] = 0.0;  // 力矩为 0
   }
 }
 


### PR DESCRIPTION
## Summary
- rename the hybrid joint controller member variables across the right arm, left arm, and neck plugins to use clearer, descriptive names
- update the controller implementations to use the new names for buffers, subscriber handles, and default gain parameters
- raise the default kp/kd gains in the bringup launch files so the joints have non-zero stiffness by default

## Testing
- `catkin_make` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d54b66e73883239254607daed2306a