### PR TITLE
Add namespaced hybrid controllers for waist, arm, and leg

### DIFF
--- a/src/simple_hybrid_joint_controller_arm/CMakeLists.txt
+++ b/src/simple_hybrid_joint_controller_arm/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(simple_hybrid_joint_controller_arm)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  controller_interface
+  hardware_interface
+  pluginlib
+  std_msgs
+  legged_common
+)
+
+catkin_package(
+  CATKIN_DEPENDS roscpp controller_interface hardware_interface pluginlib std_msgs legged_common
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}
+  src/AllJointsHybridController.cpp
+)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(FILES simple_hybrid_joint_controller_arm_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/src/simple_hybrid_joint_controller_arm/include/simple_hybrid_joint_controller_arm/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_arm/include/simple_hybrid_joint_controller_arm/AllJointsHybridController.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <ros/ros.h>
+#include <std_msgs/Float64MultiArray.h>
+#include <controller_interface/controller.h>
+#include <legged_common/hardware_interface/HybridJointInterface.h>
+
+namespace simple_hjc {
+
+class AllJointsHybridController
+  : public controller_interface::Controller<legged::HybridJointInterface> {
+public:
+  bool init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
+
+  // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
+  std::vector<std::array<double,5>> jointCommandBuffer_;
+
+  // 默认参数
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
+
+  // 订阅者
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
+
+  void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+};
+
+} // namespace simple_hjc

--- a/src/simple_hybrid_joint_controller_arm/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_arm/launch/bringup_real.launch
@@ -1,0 +1,33 @@
+<launch>
+  <!-- 为手臂硬件设置私有串口参数 -->
+  <arg name="port" default="/dev/mcu_arm"/>
+  <arg name="baud" default="921600"/>
+  <param name="arm/port" value="$(arg port)"/>
+  <param name="arm/baud" value="$(arg baud)"/>
+
+  <!-- 硬件 bringup（会带 controller_manager） -->
+  <include file="$(find legged_dm_hw)/launch/legged_dm_hw.launch">
+    <arg name="ns" value="arm"/>
+  </include>
+
+  <!-- 必须：URDF 里已经有这些手臂 joints -->
+  <group ns="arm">
+    <rosparam param="joint_state_controller">
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
+    </rosparam>
+
+    <rosparam param="all_joints_hjc_arm">
+      type: simple_hjc/AllJointsHybridController
+      joints: ['arm_joint_1','arm_joint_2','arm_joint_3','arm_joint_4','arm_joint_5','arm_joint_6','arm_joint_7']
+      default_kp: 20.0
+      default_kd: 1.0
+      default_vel: 0.0
+      default_ff:  0.0
+    </rosparam>
+
+    <node pkg="controller_manager" type="spawner" name="spawner_arm"
+          output="screen"
+          args="joint_state_controller all_joints_hjc_arm"/>
+  </group>
+</launch>

--- a/src/simple_hybrid_joint_controller_arm/package.xml
+++ b/src/simple_hybrid_joint_controller_arm/package.xml
@@ -1,0 +1,27 @@
+<package format="2">
+  <name>simple_hybrid_joint_controller_arm</name>
+  <version>0.0.1</version>
+  <description>All-joint hybrid controller (pos/vel/kp/kd/ff) for DmHW.</description>
+  <maintainer email="you@example.com">you</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>legged_common</build_depend>
+
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>controller_interface</exec_depend>
+  <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>legged_common</exec_depend>
+
+  <export>
+    <controller_interface plugin="${prefix}/simple_hybrid_joint_controller_arm_plugins.xml"/>
+  </export>
+</package>

--- a/src/simple_hybrid_joint_controller_arm/simple_hybrid_joint_controller_arm_plugins.xml
+++ b/src/simple_hybrid_joint_controller_arm/simple_hybrid_joint_controller_arm_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libsimple_hybrid_joint_controller_arm">
+  <class name="simple_hjc/AllJointsHybridController"
+         type="simple_hjc::AllJointsHybridController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>Send pos/vel/kp/kd/ff to all 10 joints via HybridJointInterface.</description>
+  </class>
+</library>

--- a/src/simple_hybrid_joint_controller_arm/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_arm/src/AllJointsHybridController.cpp
@@ -1,0 +1,175 @@
+#include "simple_hybrid_joint_controller_arm/AllJointsHybridController.h"
+#include <pluginlib/class_list_macros.hpp>
+#include <cmath>
+
+namespace simple_hjc {
+
+// 如果未在参数里给 joints，就按这个默认（可改成 14 路）
+static const std::vector<std::string> kDefaultJointNames = {
+  "arm_joint_1","arm_joint_2","arm_joint_3","arm_joint_4","arm_joint_5","arm_joint_6","arm_joint_7"
+};
+
+bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
+  // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
+  }
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
+    ROS_ERROR("No joints configured.");
+    return false;
+  }
+
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
+
+  jointHandles_.reserve(jointCount_);
+  try {
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
+    }
+  } catch (const hardware_interface::HardwareInterfaceException& e) {
+    ROS_ERROR_STREAM("Get handle failed: " << e.what());
+    return false;
+  }
+
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
+
+  // 订阅三种命令
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
+  return true;
+}
+
+void AllJointsHybridController::starting(const ros::Time&) {
+  // 将起始目标设为当前位置，避免突跳
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
+  }
+}
+
+void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
+  // 把缓存的命令写到 HybridJointHandle
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
+  }
+}
+
+void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
+  if (msg->data.size() >= 1) pos = msg->data[0];
+  if (msg->data.size() >= 2) vel = msg->data[1];
+  if (msg->data.size() >= 3) kp  = msg->data[2];
+  if (msg->data.size() >= 4) kd  = msg->data[3];
+  if (msg->data.size() >= 5) ff  = msg->data[4];
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
+  }
+}
+
+void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
+  }
+}
+
+void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    size_t base = i*5;
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
+  }
+}
+// data[0] = 关节索引（int，0..N-1）
+// data[1..5] = [pos, vel, kp, kd, ff]，可缺省；若提供且是有限数则更新，否则保持原值
+void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.empty()) {
+    ROS_WARN("command_one expects at least index and optionally 5 values");
+    return;
+  }
+  int idx = static_cast<int>(std::lrint(msg->data[0]));
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
+    return;
+  }
+
+
+  // 安全读取助手（缺省/越界 -> NaN）
+  auto getOrNaN = [&](size_t k)->double{
+    return (k < msg->data.size()) ? msg->data[k] : std::numeric_limits<double>::quiet_NaN();
+  };
+  double pos = getOrNaN(1);
+  double vel = getOrNaN(2);
+  double kp  = getOrNaN(3);
+  double kd  = getOrNaN(4);
+  double ff  = getOrNaN(5);
+
+  // 仅对“给了且是有限数”的字段做更新
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
+}
+
+
+void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("MOVE J expects %zu positions, got %zu", jointCount_, msg->data.size());
+    return;
+  }
+
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = 0.0;
+    jointCommandBuffer_[i][2] = 20.0;
+    jointCommandBuffer_[i][3] = 1.0;
+    jointCommandBuffer_[i][4] = 0.0;
+  }
+}
+
+} // namespace simple_hjc
+
+PLUGINLIB_EXPORT_CLASS(simple_hjc::AllJointsHybridController, controller_interface::ControllerBase)

--- a/src/simple_hybrid_joint_controller_leg/CMakeLists.txt
+++ b/src/simple_hybrid_joint_controller_leg/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(simple_hybrid_joint_controller_leg)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  controller_interface
+  hardware_interface
+  pluginlib
+  std_msgs
+  legged_common
+)
+
+catkin_package(
+  CATKIN_DEPENDS roscpp controller_interface hardware_interface pluginlib std_msgs legged_common
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}
+  src/AllJointsHybridController.cpp
+)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(FILES simple_hybrid_joint_controller_leg_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/src/simple_hybrid_joint_controller_leg/include/simple_hybrid_joint_controller_leg/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_leg/include/simple_hybrid_joint_controller_leg/AllJointsHybridController.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <ros/ros.h>
+#include <std_msgs/Float64MultiArray.h>
+#include <controller_interface/controller.h>
+#include <legged_common/hardware_interface/HybridJointInterface.h>
+
+namespace simple_hjc {
+
+class AllJointsHybridController
+  : public controller_interface::Controller<legged::HybridJointInterface> {
+public:
+  bool init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
+
+  // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
+  std::vector<std::array<double,5>> jointCommandBuffer_;
+
+  // 默认参数
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
+
+  // 订阅者
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
+
+  void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+};
+
+} // namespace simple_hjc

--- a/src/simple_hybrid_joint_controller_leg/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_leg/launch/bringup_real.launch
@@ -1,0 +1,34 @@
+<launch>
+  <!-- 为腿部硬件设置私有串口参数 -->
+  <arg name="port" default="/dev/mcu_leg"/>
+  <arg name="baud" default="921600"/>
+  <param name="leg/port" value="$(arg port)"/>
+  <param name="leg/baud" value="$(arg baud)"/>
+
+  <!-- 硬件 bringup（会带 controller_manager） -->
+  <include file="$(find legged_dm_hw)/launch/legged_dm_hw.launch">
+    <arg name="ns" value="leg"/>
+  </include>
+
+  <!-- 必须：URDF 里已经有这些腿部 joints -->
+  <group ns="leg">
+    <rosparam param="joint_state_controller">
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
+    </rosparam>
+
+    <rosparam param="all_joints_hjc_leg">
+      type: simple_hjc/AllJointsHybridController
+      joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
+               'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
+      default_kp: 20.0
+      default_kd: 1.0
+      default_vel: 0.0
+      default_ff:  0.0
+    </rosparam>
+
+    <node pkg="controller_manager" type="spawner" name="spawner_leg"
+          output="screen"
+          args="joint_state_controller all_joints_hjc_leg"/>
+  </group>
+</launch>

--- a/src/simple_hybrid_joint_controller_leg/package.xml
+++ b/src/simple_hybrid_joint_controller_leg/package.xml
@@ -1,0 +1,27 @@
+<package format="2">
+  <name>simple_hybrid_joint_controller_leg</name>
+  <version>0.0.1</version>
+  <description>All-joint hybrid controller (pos/vel/kp/kd/ff) for DmHW.</description>
+  <maintainer email="you@example.com">you</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>legged_common</build_depend>
+
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>controller_interface</exec_depend>
+  <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>legged_common</exec_depend>
+
+  <export>
+    <controller_interface plugin="${prefix}/simple_hybrid_joint_controller_leg_plugins.xml"/>
+  </export>
+</package>

--- a/src/simple_hybrid_joint_controller_leg/simple_hybrid_joint_controller_leg_plugins.xml
+++ b/src/simple_hybrid_joint_controller_leg/simple_hybrid_joint_controller_leg_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libsimple_hybrid_joint_controller_leg">
+  <class name="simple_hjc/AllJointsHybridController"
+         type="simple_hjc::AllJointsHybridController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>Send pos/vel/kp/kd/ff to all 10 joints via HybridJointInterface.</description>
+  </class>
+</library>

--- a/src/simple_hybrid_joint_controller_leg/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_leg/src/AllJointsHybridController.cpp
@@ -1,0 +1,177 @@
+#include "simple_hybrid_joint_controller_leg/AllJointsHybridController.h"
+#include <pluginlib/class_list_macros.hpp>
+#include <cmath>
+
+namespace simple_hjc {
+
+// 如果未在参数里给 joints，就按这个默认（可改成 14 路）
+static const std::vector<std::string> kDefaultJointNames = {
+  "leg_l1_joint","leg_l2_joint","leg_l3_joint","leg_l4_joint","leg_l5_joint","leg_l6_joint","leg_l7_joint",
+  "leg_r1_joint","leg_r2_joint","leg_r3_joint","leg_r4_joint","leg_r5_joint","leg_r6_joint","leg_r7_joint"
+};
+
+bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
+  // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
+  }
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
+    ROS_ERROR("No joints configured.");
+    return false;
+  }
+
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
+
+  jointHandles_.reserve(jointCount_);
+  try {
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
+    }
+  } catch (const hardware_interface::HardwareInterfaceException& e) {
+    ROS_ERROR_STREAM("Get handle failed: " << e.what());
+    return false;
+  }
+
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
+
+  // 订阅三种命令
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
+  return true;
+}
+
+void AllJointsHybridController::starting(const ros::Time&) {
+  // 将起始目标设为当前位置，避免突跳
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
+  }
+}
+
+void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
+  // 把缓存的命令写到 HybridJointHandle
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
+  }
+}
+
+void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
+  if (msg->data.size() >= 1) pos = msg->data[0];
+  if (msg->data.size() >= 2) vel = msg->data[1];
+  if (msg->data.size() >= 3) kp  = msg->data[2];
+  if (msg->data.size() >= 4) kd  = msg->data[3];
+  if (msg->data.size() >= 5) ff  = msg->data[4];
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
+  }
+}
+
+void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
+  }
+}
+
+void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    size_t base = i*5;
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
+  }
+}
+// data[0] = 关节索引（int，0..N-1）
+// data[1..5] = [pos, vel, kp, kd, ff]，可缺省；若提供且是有限数则更新，否则保持原值
+void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.empty()) {
+    ROS_WARN("command_one expects at least index and optionally 5 values");
+    return;
+  }
+  int idx = static_cast<int>(std::lrint(msg->data[0]));
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
+    return;
+  }
+
+
+  // 安全读取助手（缺省/越界 -> NaN）
+  auto getOrNaN = [&](size_t k)->double{
+    return (k < msg->data.size()) ? msg->data[k] : std::numeric_limits<double>::quiet_NaN();
+  };
+  double pos = getOrNaN(1);
+  double vel = getOrNaN(2);
+  double kp  = getOrNaN(3);
+  double kd  = getOrNaN(4);
+  double ff  = getOrNaN(5);
+
+  // 仅对“给了且是有限数”的字段做更新
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
+}
+
+
+void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < 7) {  // 确保至少有 7 个位置数据
+    ROS_WARN("MOVE J expects 7 positions, got %zu", msg->data.size());
+    return;
+  }
+
+  // 目标关节位置为从位置 7 到 13（即 idx 7 到 idx 13），假设电机编号从 0 开始
+  for (size_t i = 7; i < 14; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i - 7];  // 将输入的位置传递给对应的电机
+    jointCommandBuffer_[i][1] = 0.0;  // 速度设为 0
+    jointCommandBuffer_[i][2] = 20.0; // Kp 设置为 20
+    jointCommandBuffer_[i][3] = 1.0;  // Kd 设置为 1
+    jointCommandBuffer_[i][4] = 0.0;  // 力矩为 0
+  }
+}
+
+} // namespace simple_hjc
+
+PLUGINLIB_EXPORT_CLASS(simple_hjc::AllJointsHybridController, controller_interface::ControllerBase)

--- a/src/simple_hybrid_joint_controller_waist/CMakeLists.txt
+++ b/src/simple_hybrid_joint_controller_waist/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(simple_hybrid_joint_controller_waist)
+
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  controller_interface
+  hardware_interface
+  pluginlib
+  std_msgs
+  legged_common
+)
+
+catkin_package(
+  CATKIN_DEPENDS roscpp controller_interface hardware_interface pluginlib std_msgs legged_common
+)
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_library(${PROJECT_NAME}
+  src/AllJointsHybridController.cpp
+)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+install(FILES simple_hybrid_joint_controller_waist_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})

--- a/src/simple_hybrid_joint_controller_waist/include/simple_hybrid_joint_controller_waist/AllJointsHybridController.h
+++ b/src/simple_hybrid_joint_controller_waist/include/simple_hybrid_joint_controller_waist/AllJointsHybridController.h
@@ -1,0 +1,44 @@
+#pragma once
+#include <ros/ros.h>
+#include <std_msgs/Float64MultiArray.h>
+#include <controller_interface/controller.h>
+#include <legged_common/hardware_interface/HybridJointInterface.h>
+
+namespace simple_hjc {
+
+class AllJointsHybridController
+  : public controller_interface::Controller<legged::HybridJointInterface> {
+public:
+  bool init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  std::vector<legged::HybridJointHandle> jointHandles_;
+  std::vector<std::string> jointNames_;
+  size_t jointCount_{0};  // 关节数 = joints.size()
+
+  // 命令缓存：N x 5 (pos, vel, kp, kd, ff)
+  std::vector<std::array<double,5>> jointCommandBuffer_;
+
+  // 默认参数
+  double defaultPositionGain_{100.0};
+  double defaultDampingGain_{2.0};
+  double defaultVelocityCommand_{0.0};
+  double defaultFeedforwardTorque_{0.0};
+
+  // 订阅者
+  ros::Subscriber sameCommandSub_;
+  ros::Subscriber positionArraySub_;
+  ros::Subscriber matrixCommandSub_;
+  ros::Subscriber singleJointSub_;
+  ros::Subscriber moveJointSub_;
+
+  void sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+  void moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
+};
+
+} // namespace simple_hjc

--- a/src/simple_hybrid_joint_controller_waist/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_waist/launch/bringup_real.launch
@@ -1,0 +1,33 @@
+<launch>
+  <!-- 为腰部硬件设置私有串口参数 -->
+  <arg name="port" default="/dev/mcu_waist"/>
+  <arg name="baud" default="921600"/>
+  <param name="waist/port" value="$(arg port)"/>
+  <param name="waist/baud" value="$(arg baud)"/>
+
+  <!-- 硬件 bringup（会带 controller_manager） -->
+  <include file="$(find legged_dm_hw)/launch/legged_dm_hw.launch">
+    <arg name="ns" value="waist"/>
+  </include>
+
+  <!-- 必须：URDF 里已经有这些腰部 joints -->
+  <group ns="waist">
+    <rosparam param="joint_state_controller">
+      type: joint_state_controller/JointStateController
+      publish_rate: 100
+    </rosparam>
+
+    <rosparam param="all_joints_hjc_waist">
+      type: simple_hjc/AllJointsHybridController
+      joints: ['waist_joint_1','waist_joint_2','waist_joint_3']
+      default_kp: 20.0
+      default_kd: 1.0
+      default_vel: 0.0
+      default_ff:  0.0
+    </rosparam>
+
+    <node pkg="controller_manager" type="spawner" name="spawner_waist"
+          output="screen"
+          args="joint_state_controller all_joints_hjc_waist"/>
+  </group>
+</launch>

--- a/src/simple_hybrid_joint_controller_waist/package.xml
+++ b/src/simple_hybrid_joint_controller_waist/package.xml
@@ -1,0 +1,27 @@
+<package format="2">
+  <name>simple_hybrid_joint_controller_waist</name>
+  <version>0.0.1</version>
+  <description>All-joint hybrid controller (pos/vel/kp/kd/ff) for DmHW.</description>
+  <maintainer email="you@example.com">you</maintainer>
+  <license>BSD</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>roscpp</build_depend>
+  <build_depend>controller_interface</build_depend>
+  <build_depend>hardware_interface</build_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>legged_common</build_depend>
+
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>controller_interface</exec_depend>
+  <exec_depend>hardware_interface</exec_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>legged_common</exec_depend>
+
+  <export>
+    <controller_interface plugin="${prefix}/simple_hybrid_joint_controller_waist_plugins.xml"/>
+  </export>
+</package>

--- a/src/simple_hybrid_joint_controller_waist/simple_hybrid_joint_controller_waist_plugins.xml
+++ b/src/simple_hybrid_joint_controller_waist/simple_hybrid_joint_controller_waist_plugins.xml
@@ -1,0 +1,7 @@
+<library path="lib/libsimple_hybrid_joint_controller_waist">
+  <class name="simple_hjc/AllJointsHybridController"
+         type="simple_hjc::AllJointsHybridController"
+         base_class_type="controller_interface::ControllerBase">
+    <description>Send pos/vel/kp/kd/ff to all 10 joints via HybridJointInterface.</description>
+  </class>
+</library>

--- a/src/simple_hybrid_joint_controller_waist/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_waist/src/AllJointsHybridController.cpp
@@ -1,0 +1,175 @@
+#include "simple_hybrid_joint_controller_waist/AllJointsHybridController.h"
+#include <pluginlib/class_list_macros.hpp>
+#include <cmath>
+
+namespace simple_hjc {
+
+// 如果未在参数里给 joints，就按这个默认（可改成 14 路）
+static const std::vector<std::string> kDefaultJointNames = {
+  "waist_joint_1","waist_joint_2","waist_joint_3"
+};
+
+bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
+  // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）
+  if (!nh.getParam("joints", jointNames_)) {
+    jointNames_ = kDefaultJointNames;
+    ROS_WARN("param '~joints' not set, using default (%zu)", jointNames_.size());
+  }
+  jointCount_ = jointNames_.size();
+  if (jointCount_ == 0) {
+    ROS_ERROR("No joints configured.");
+    return false;
+  }
+
+  nh.param("default_kp", defaultPositionGain_, 100.0);
+  nh.param("default_kd", defaultDampingGain_, 2.0);
+  nh.param("default_vel", defaultVelocityCommand_, 0.0);
+  nh.param("default_ff",  defaultFeedforwardTorque_,  0.0);
+
+  jointHandles_.reserve(jointCount_);
+  try {
+    for (const auto& name : jointNames_) {
+      jointHandles_.push_back(hw->getHandle(name));
+    }
+  } catch (const hardware_interface::HardwareInterfaceException& e) {
+    ROS_ERROR_STREAM("Get handle failed: " << e.what());
+    return false;
+  }
+
+  jointCommandBuffer_.assign(jointCount_, {0,0,0,0,0});
+
+  // 订阅三种命令
+  sameCommandSub_    = nh.subscribe("command_same",   1, &AllJointsHybridController::sameCb,   this);
+  positionArraySub_  = nh.subscribe("command_pos_all",1, &AllJointsHybridController::posAllCb, this);
+  matrixCommandSub_  = nh.subscribe("command_matrix", 1, &AllJointsHybridController::matrixCb, this);
+  singleJointSub_    = nh.subscribe("command_one",    5, &AllJointsHybridController::oneCb,    this);
+  moveJointSub_      = nh.subscribe("command_moveJ",  1, &AllJointsHybridController::moveJCb,  this);
+
+  ROS_INFO("AllJointsHybridController ready with %zu joints.", jointCount_);
+  return true;
+}
+
+void AllJointsHybridController::starting(const ros::Time&) {
+  // 将起始目标设为当前位置，避免突跳
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = jointHandles_[i].getPosition(); // pos
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;         // vel
+    jointCommandBuffer_[i][2] = defaultPositionGain_;            // kp
+    jointCommandBuffer_[i][3] = defaultDampingGain_;             // kd
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;       // ff
+  }
+}
+
+void AllJointsHybridController::update(const ros::Time&, const ros::Duration&) {
+  // 把缓存的命令写到 HybridJointHandle
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointHandles_[i].setCommand(jointCommandBuffer_[i][0],
+                                jointCommandBuffer_[i][1],
+                                jointCommandBuffer_[i][2],
+                                jointCommandBuffer_[i][3],
+                                jointCommandBuffer_[i][4]);
+  }
+}
+
+void AllJointsHybridController::sameCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 期望 [pos, vel, kp, kd, ff]，支持只给前几项
+  double pos = jointCommandBuffer_[0][0];
+  double vel = defaultVelocityCommand_;
+  double kp = defaultPositionGain_;
+  double kd = defaultDampingGain_;
+  double ff = defaultFeedforwardTorque_;
+  if (msg->data.size() >= 1) pos = msg->data[0];
+  if (msg->data.size() >= 2) vel = msg->data[1];
+  if (msg->data.size() >= 3) kp  = msg->data[2];
+  if (msg->data.size() >= 4) kd  = msg->data[3];
+  if (msg->data.size() >= 5) ff  = msg->data[4];
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = pos;
+    jointCommandBuffer_[i][1] = vel;
+    jointCommandBuffer_[i][2] = kp;
+    jointCommandBuffer_[i][3] = kd;
+    jointCommandBuffer_[i][4] = ff;
+  }
+}
+
+void AllJointsHybridController::posAllCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("command_pos_all expects %zu positions, got %zu", jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = defaultVelocityCommand_;
+    jointCommandBuffer_[i][2] = defaultPositionGain_;
+    jointCommandBuffer_[i][3] = defaultDampingGain_;
+    jointCommandBuffer_[i][4] = defaultFeedforwardTorque_;
+  }
+}
+
+void AllJointsHybridController::matrixCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  // 行优先：第 i 行是第 i 个关节，共 N 行，每行 5 个
+  if (msg->data.size() < 5 * jointCount_) {
+    ROS_WARN("command_matrix expects %zu values (%zux5), got %zu",
+             5 * jointCount_, jointCount_, msg->data.size());
+    return;
+  }
+  for (size_t i = 0; i < jointCount_; ++i) {
+    size_t base = i*5;
+    jointCommandBuffer_[i][0] = msg->data[base + 0];  // pos
+    jointCommandBuffer_[i][1] = msg->data[base + 1];  // vel
+    jointCommandBuffer_[i][2] = msg->data[base + 2];  // kp
+    jointCommandBuffer_[i][3] = msg->data[base + 3];  // kd
+    jointCommandBuffer_[i][4] = msg->data[base + 4];  // ff
+  }
+}
+// data[0] = 关节索引（int，0..N-1）
+// data[1..5] = [pos, vel, kp, kd, ff]，可缺省；若提供且是有限数则更新，否则保持原值
+void AllJointsHybridController::oneCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.empty()) {
+    ROS_WARN("command_one expects at least index and optionally 5 values");
+    return;
+  }
+  int idx = static_cast<int>(std::lrint(msg->data[0]));
+  if (idx < 0 || idx >= static_cast<int>(jointCount_)) {
+    ROS_WARN("command_one: bad joint index %d (valid 0..%zu)", idx, jointCount_ - 1);
+    return;
+  }
+
+
+  // 安全读取助手（缺省/越界 -> NaN）
+  auto getOrNaN = [&](size_t k)->double{
+    return (k < msg->data.size()) ? msg->data[k] : std::numeric_limits<double>::quiet_NaN();
+  };
+  double pos = getOrNaN(1);
+  double vel = getOrNaN(2);
+  double kp  = getOrNaN(3);
+  double kd  = getOrNaN(4);
+  double ff  = getOrNaN(5);
+
+  // 仅对“给了且是有限数”的字段做更新
+  if (std::isfinite(pos)) jointCommandBuffer_[idx][0] = pos;
+  if (std::isfinite(vel)) jointCommandBuffer_[idx][1] = vel;
+  if (std::isfinite(kp )) jointCommandBuffer_[idx][2] = kp;
+  if (std::isfinite(kd )) jointCommandBuffer_[idx][3] = kd;
+  if (std::isfinite(ff )) jointCommandBuffer_[idx][4] = ff;
+}
+
+
+void AllJointsHybridController::moveJCb(const std_msgs::Float64MultiArray::ConstPtr& msg) {
+  if (msg->data.size() < jointCount_) {
+    ROS_WARN("MOVE J expects %zu positions, got %zu", jointCount_, msg->data.size());
+    return;
+  }
+
+  for (size_t i = 0; i < jointCount_; ++i) {
+    jointCommandBuffer_[i][0] = msg->data[i];
+    jointCommandBuffer_[i][1] = 0.0;
+    jointCommandBuffer_[i][2] = 20.0;
+    jointCommandBuffer_[i][3] = 1.0;
+    jointCommandBuffer_[i][4] = 0.0;
+  }
+}
+
+} // namespace simple_hjc
+
+PLUGINLIB_EXPORT_CLASS(simple_hjc::AllJointsHybridController, controller_interface::ControllerBase)


### PR DESCRIPTION
## Summary
- add a `simple_hybrid_joint_controller_arm` package with its own plugin registration, launch file, and arm joint defaults
- add a `simple_hybrid_joint_controller_leg` package so the leg controllers can run in an isolated namespace
- add a `simple_hybrid_joint_controller_waist` package with waist-specific defaults and a generalized MOVE J handler

## Testing
- catkin_make *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d61f71a6508323a6e23db58026439e