### PR TITLE
Modularize Wanren hardware configuration

### DIFF
--- a/src/README-wzy.md
+++ b/src/README-wzy.md
@@ -25,7 +25,7 @@ rosparam set /all_joints_hjc/default_kp 0.0
 rosparam set /all_joints_hjc/default_kd 0.0
 rosparam set /all_joints_hjc/default_vel 0.0
 rosparam set /all_joints_hjc/default_ff  0.0
-rosparam set /all_joints_hjc/joints "['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint']"
+rosparam set /all_joints_hjc/joints "['leg_left_joint_1','leg_left_joint_2','leg_left_joint_3','leg_left_joint_4','leg_left_joint_5','leg_right_joint_1','leg_right_joint_2','leg_right_joint_3','leg_right_joint_4','leg_right_joint_5']"
 
 rosrun controller_manager spawner joint_state_controller all_joints_hjc
 
@@ -56,7 +56,7 @@ rostopic echo -n 1 /joint_states
 
 1) 写入控制器参数（让 controller_manager 知道它是什么）
 rosparam set /all_joints_hjc/type "simple_hjc/AllJointsHybridController"
-rosparam set /all_joints_hjc/joints "['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint']"
+rosparam set /all_joints_hjc/joints "['leg_left_joint_1','leg_left_joint_2','leg_left_joint_3','leg_left_joint_4','leg_left_joint_5','leg_right_joint_1','leg_right_joint_2','leg_right_joint_3','leg_right_joint_4','leg_right_joint_5']"
 rosparam set /all_joints_hjc/default_kp 0.0
 rosparam set /all_joints_hjc/default_kd 0.0
 rosparam set /all_joints_hjc/default_vel 0.0

--- a/src/legged_examples/legged_dm_description/rviz/urdf.rviz
+++ b/src/legged_examples/legged_dm_description/rviz/urdf.rviz
@@ -73,72 +73,72 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l1_link:
+        leg_left_link_1:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l2_link:
+        leg_left_link_2:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l3_link:
+        leg_left_link_3:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l4_link:
+        leg_left_link_4:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l5_link:
+        leg_left_link_5:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l_f1_link:
+        leg_left_f1_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_l_f2_link:
+        leg_left_f2_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r1_link:
+        leg_right_link_1:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r2_link:
+        leg_right_link_2:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r3_link:
+        leg_right_link_3:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r4_link:
+        leg_right_link_4:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r5_link:
+        leg_right_link_5:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r_f1_link:
+        leg_right_f1_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
           Value: true
-        leg_r_f2_link:
+        leg_right_f2_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -160,33 +160,33 @@ Visualization Manager:
           Value: true
         imu_link:
           Value: true
-        leg_l1_link:
+        leg_left_link_1:
           Value: true
-        leg_l2_link:
+        leg_left_link_2:
           Value: true
-        leg_l3_link:
+        leg_left_link_3:
           Value: true
-        leg_l4_link:
+        leg_left_link_4:
           Value: true
-        leg_l5_link:
+        leg_left_link_5:
           Value: true
-        leg_l_f1_link:
+        leg_left_f1_link:
           Value: true
-        leg_l_f2_link:
+        leg_left_f2_link:
           Value: true
-        leg_r1_link:
+        leg_right_link_1:
           Value: true
-        leg_r2_link:
+        leg_right_link_2:
           Value: true
-        leg_r3_link:
+        leg_right_link_3:
           Value: true
-        leg_r4_link:
+        leg_right_link_4:
           Value: true
-        leg_r5_link:
+        leg_right_link_5:
           Value: true
-        leg_r_f1_link:
+        leg_right_f1_link:
           Value: true
-        leg_r_f2_link:
+        leg_right_f2_link:
           Value: true
       Marker Alpha: 1
       Marker Scale: 0.10000000149011612
@@ -198,23 +198,23 @@ Visualization Manager:
         base_link:
           imu_link:
             {}
-          leg_l1_link:
-            leg_l2_link:
-              leg_l3_link:
-                leg_l4_link:
-                  leg_l5_link:
-                    leg_l_f1_link:
+          leg_left_link_1:
+            leg_left_link_2:
+              leg_left_link_3:
+                leg_left_link_4:
+                  leg_left_link_5:
+                    leg_left_f1_link:
                       {}
-                    leg_l_f2_link:
+                    leg_left_f2_link:
                       {}
-          leg_r1_link:
-            leg_r2_link:
-              leg_r3_link:
-                leg_r4_link:
-                  leg_r5_link:
-                    leg_r_f1_link:
+          leg_right_link_1:
+            leg_right_link_2:
+              leg_right_link_3:
+                leg_right_link_4:
+                  leg_right_link_5:
+                    leg_right_f1_link:
                       {}
-                    leg_r_f2_link:
+                    leg_right_f2_link:
                       {}
       Update Interval: 0
       Value: true

--- a/src/legged_examples/legged_dm_description/urdf/dm.urdf
+++ b/src/legged_examples/legged_dm_description/urdf/dm.urdf
@@ -151,7 +151,7 @@
   
   
   <link
-    name="leg_l1_link">
+    name="leg_left_link_1">
     <inertial>
       <origin
         xyz="0.003165 0.041652 -0.000064"
@@ -172,7 +172,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_l1_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_left_link_1.STL" />
       </geometry>
       <material
         name="">
@@ -190,7 +190,7 @@
     </collision>
   </link>
   <joint
-    name="leg_l1_joint"
+    name="leg_left_joint_1"
     type="revolute">
     <origin
       xyz="3.7385E-05 0.05355 -0.062"
@@ -198,7 +198,7 @@
     <parent
       link="loin_yaw_Link" />
     <child
-      link="leg_l1_link" />
+      link="leg_left_link_1" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -210,7 +210,7 @@
   
   
   <link
-    name="leg_l2_link">
+    name="leg_left_link_2">
     <inertial>
       <origin
         xyz="-0.031797 0.000022 -0.037074"
@@ -231,7 +231,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_l2_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_left_link_2.STL" />
       </geometry>
       <material
         name="">
@@ -249,15 +249,15 @@
     </collision>
   </link>
   <joint
-    name="leg_l2_joint"
+    name="leg_left_joint_2"
     type="revolute">
     <origin
       xyz="0.031079 0.041978 0"
       rpy="0 0 0" />
     <parent
-      link="leg_l1_link" />
+      link="leg_left_link_1" />
     <child
-      link="leg_l2_link" />
+      link="leg_left_link_2" />
     <axis
       xyz="1 0 0" />
     <limit
@@ -269,7 +269,7 @@
   
   
   <link
-    name="leg_l3_link">
+    name="leg_left_link_3">
     <inertial>
       <origin
         xyz="-0.000094 0.001497 -0.07069"
@@ -290,7 +290,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_l3_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_left_link_3.STL" />
       </geometry>
       <material
         name="">
@@ -308,15 +308,15 @@
     </collision>
   </link>
   <joint
-    name="leg_l3_joint"
+    name="leg_left_joint_3"
     type="revolute">
     <origin
       xyz="-0.03105 2.1677E-05 -0.07405"
       rpy="0 0 0" />
     <parent
-      link="leg_l2_link" />
+      link="leg_left_link_2" />
     <child
-      link="leg_l3_link" />
+      link="leg_left_link_3" />
     <axis
       xyz="0 0 1" />
     <limit
@@ -328,7 +328,7 @@
   
   
   <link
-    name="leg_l4_link">
+    name="leg_left_link_4">
     <inertial>
       <origin
         xyz="-0.003284 -0.032312 -0.084258"
@@ -349,7 +349,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_l4_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_left_link_4.STL" />
       </geometry>
       <material
         name="">
@@ -365,15 +365,15 @@
     </collision>
   </link>
   <joint
-    name="leg_l4_joint"
+    name="leg_left_joint_4"
     type="revolute">
     <origin
       xyz="2.1677E-05 0.03105 -0.11705"
       rpy="0 0 0" />
     <parent
-      link="leg_l3_link" />
+      link="leg_left_link_3" />
     <child
-      link="leg_l4_link" />
+      link="leg_left_link_4" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -385,7 +385,7 @@
   
   
   <link
-    name="leg_l5_link">
+    name="leg_left_link_5">
     <inertial>
       <origin
         xyz="0.01392 -0.008010 -0.013513"
@@ -406,7 +406,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_l5_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_left_link_5.STL" />
       </geometry>
       <material
         name="">
@@ -424,15 +424,15 @@
     </collision>
   </link>
   <joint
-    name="leg_l5_joint"
+    name="leg_left_joint_5"
     type="revolute">
     <origin
       xyz="-3.1151E-05 -0.02305 -0.2"
       rpy="0 0 0" />
     <parent
-      link="leg_l4_link" />
+      link="leg_left_link_4" />
     <child
-      link="leg_l5_link" />
+      link="leg_left_link_5" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -442,7 +442,7 @@
       velocity="10" />
   </joint>
     <!-- ===== Left leg extra joints for 6 & 7 ===== -->
-  <link name="leg_l6_link">
+  <link name="leg_left_link_6">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <mass value="0.01"/>
@@ -451,15 +451,15 @@
     <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></visual>
     <collision><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></collision>
   </link>
-  <joint name="leg_l6_joint" type="revolute">
+  <joint name="leg_left_joint_6" type="revolute">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-    <parent link="leg_l5_link"/>
-    <child  link="leg_l6_link"/>
+    <parent link="leg_left_link_5"/>
+    <child  link="leg_left_link_6"/>
     <axis xyz="0 1 0"/>
     <limit lower="-1.57" upper="1.57" effort="26" velocity="10"/>
   </joint>
 
-  <link name="leg_l7_link">
+  <link name="leg_left_link_7">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <mass value="0.01"/>
@@ -468,22 +468,22 @@
     <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></visual>
     <collision><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></collision>
   </link>
-  <joint name="leg_l7_joint" type="revolute">
+  <joint name="leg_left_joint_7" type="revolute">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-    <parent link="leg_l6_link"/>
-    <child  link="leg_l7_link"/>
+    <parent link="leg_left_link_6"/>
+    <child  link="leg_left_link_7"/>
     <axis xyz="0 1 0"/>
     <limit lower="-1.57" upper="1.57" effort="26" velocity="10"/>
   </joint>
 
   
   
-  <joint name="leg_l5_fixed_1" type="fixed">
+  <joint name="leg_left_fixed_1" type="fixed">
     <origin xyz="0.113 -0.008 -0.006" rpy="0 0 0" />
-    <parent link="leg_l5_link" />
-    <child link="leg_l_f1_link" />
+    <parent link="leg_left_link_5" />
+    <child link="leg_left_f1_link" />
   </joint>
-  <link name="leg_l_f1_link">
+  <link name="leg_left_f1_link">
     <inertial>
       <mass value="0.01" />
       <inertia ixx="0.000001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.000001" />
@@ -502,12 +502,12 @@
     </collision>
   </link>
 
-  <joint name="leg_l5_fixed_2" type="fixed">
+  <joint name="leg_left_fixed_2" type="fixed">
     <origin xyz="-0.061 -0.008 -0.006" rpy="0 0 0" />
-    <parent link="leg_l5_link" />
-    <child link="leg_l_f2_link" />
+    <parent link="leg_left_link_5" />
+    <child link="leg_left_f2_link" />
   </joint>
-  <link name="leg_l_f2_link">
+  <link name="leg_left_f2_link">
     <inertial>
       <mass value="0.01" />
       <inertia ixx="0.000001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.000001" />
@@ -526,27 +526,27 @@
     </collision>
   </link>
 
-   <gazebo reference="leg_l1_link">
+   <gazebo reference="leg_left_link_1">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_l2_link">
+  <gazebo reference="leg_left_link_2">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_l3_link">
+  <gazebo reference="leg_left_link_3">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_l4_link">
+  <gazebo reference="leg_left_link_4">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_l5_link">
+  <gazebo reference="leg_left_link_5">
     <mu1>0.7</mu1>
     <mu2>0.7</mu2>
     <self_collide>1</self_collide>
@@ -555,7 +555,7 @@
     <maxVel>1.0</maxVel>
     <minDepth>0.00</minDepth>
   </gazebo>
-  <gazebo reference="leg_l_f1_link">
+  <gazebo reference="leg_left_f1_link">
     <mu1>1.5</mu1>
     <mu2>1.5</mu2>
     <self_collide>1</self_collide>
@@ -564,7 +564,7 @@
     <maxVel>1.0</maxVel>
     <minDepth>0.00</minDepth>
   </gazebo>
-  <gazebo reference="leg_l_f2_link">
+  <gazebo reference="leg_left_f2_link">
     <mu1>1.5</mu1>
     <mu2>1.5</mu2>
     <self_collide>1</self_collide>
@@ -574,12 +574,12 @@
     <minDepth>0.00</minDepth>
   </gazebo>
 
-  <transmission name="leg_l1_tran">
+  <transmission name="leg_left_tran_1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l1_joint">
+    <joint name="leg_left_joint_1">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l1_motor">
+    <actuator name="leg_left_motor_1">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     <maxVelocity>1.484</maxVelocity><!-- 85rpm -->
@@ -587,12 +587,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_l2_tran">
+  <transmission name="leg_left_tran_2">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l2_joint">
+    <joint name="leg_left_joint_2">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l2_motor">
+    <actuator name="leg_left_motor_2">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     <maxVelocity>2.6545</maxVelocity><!-- 160rpm -->
@@ -600,12 +600,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_l3_tran">
+  <transmission name="leg_left_tran_3">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l3_joint">
+    <joint name="leg_left_joint_3">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l3_motor">
+    <actuator name="leg_left_motor_3">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     <maxVelocity>2.6545</maxVelocity><!-- 160rpm -->
@@ -613,12 +613,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_l4_tran">
+  <transmission name="leg_left_tran_4">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l4_joint">
+    <joint name="leg_left_joint_4">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l4_motor">
+    <actuator name="leg_left_motor_4">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     <maxVelocity>1.484</maxVelocity><!-- 85rpm -->
@@ -626,34 +626,34 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_l5_tran">
+  <transmission name="leg_left_tran_5">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l5_joint">
+    <joint name="leg_left_joint_5">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l5_motor">
+    <actuator name="leg_left_motor_5">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
 
-    <transmission name="leg_l6_tran">
+    <transmission name="leg_left_tran_6">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l6_joint">
+    <joint name="leg_left_joint_6">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l6_motor">
+    <actuator name="leg_left_motor_6">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
 
-  <transmission name="leg_l7_tran">
+  <transmission name="leg_left_tran_7">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_l7_joint">
+    <joint name="leg_left_joint_7">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_l7_motor">
+    <actuator name="leg_left_motor_7">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
@@ -664,7 +664,7 @@
 
   
   <link
-    name="leg_r1_link">
+    name="leg_right_link_1">
     <inertial>
       <origin
         xyz="0.003106 -0.041675 -0.000072"
@@ -685,7 +685,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_r1_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_right_link_1.STL" />
       </geometry>
       <material
         name="">
@@ -703,7 +703,7 @@
     </collision>
   </link>
   <joint
-    name="leg_r1_joint"
+    name="leg_right_joint_1"
     type="revolute">
     <origin
       xyz="-3.7385E-05 -0.05355 -0.062"
@@ -711,7 +711,7 @@
     <parent
       link="loin_yaw_Link" />
     <child
-      link="leg_r1_link" />
+      link="leg_right_link_1" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -723,7 +723,7 @@
   
   
   <link
-    name="leg_r2_link">
+    name="leg_right_link_2">
     <inertial>
       <origin
         xyz="-0.031797 0.000022 -0.037074"
@@ -744,7 +744,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_r2_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_right_link_2.STL" />
       </geometry>
       <material
         name="">
@@ -762,15 +762,15 @@
     </collision>
   </link>
   <joint
-    name="leg_r2_joint"
+    name="leg_right_joint_2"
     type="revolute">
     <origin
       xyz="0.031021 -0.042022 0"
       rpy="0 0 0" />
     <parent
-      link="leg_r1_link" />
+      link="leg_right_link_1" />
     <child
-      link="leg_r2_link" />
+      link="leg_right_link_2" />
     <axis
       xyz="1 0 0" />
     <limit
@@ -782,7 +782,7 @@
   
   
   <link
-    name="leg_r3_link">
+    name="leg_right_link_3">
     <inertial>
       <origin
         xyz="0.000186 -0.001497 -0.070691"
@@ -803,7 +803,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_r3_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_right_link_3.STL" />
       </geometry>
       <material
         name="">
@@ -821,15 +821,15 @@
     </collision>
   </link>
   <joint
-    name="leg_r3_joint"
+    name="leg_right_joint_3"
     type="revolute">
     <origin
       xyz="-0.03105 2.1677E-05 -0.07405"
       rpy="0 0 0" />
     <parent
-      link="leg_r2_link" />
+      link="leg_right_link_2" />
     <child
-      link="leg_r3_link" />
+      link="leg_right_link_3" />
     <axis
       xyz="0 0 1" />
     <limit
@@ -841,7 +841,7 @@
   
   
   <link
-    name="leg_r4_link">
+    name="leg_right_link_4">
     <inertial>
       <origin
         xyz="-0.00318 0.032366 -0.084259"
@@ -862,7 +862,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_r4_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_right_link_4.STL" />
       </geometry>
       <material
         name="">
@@ -878,15 +878,15 @@
     </collision>
   </link>
   <joint
-    name="leg_r4_joint"
+    name="leg_right_joint_4"
     type="revolute">
     <origin
       xyz="-2.1677E-05 -0.03105 -0.11705"
       rpy="0 0 0" />
     <parent
-      link="leg_r3_link" />
+      link="leg_right_link_3" />
     <child
-      link="leg_r4_link" />
+      link="leg_right_link_4" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -898,7 +898,7 @@
   
   
   <link
-    name="leg_r5_link">
+    name="leg_right_link_5">
     <inertial>
       <origin
         xyz="0.013933 0.007990 -0.013512"
@@ -919,7 +919,7 @@
         rpy="0 0 0" />
       <geometry>
         <mesh
-          filename="package://legged_dm_description/meshes/leg_r5_link.STL" />
+          filename="package://legged_dm_description/meshes/leg_right_link_5.STL" />
       </geometry>
       <material
         name="">
@@ -937,15 +937,15 @@
     </collision>
   </link>
   <joint
-    name="leg_r5_joint"
+    name="leg_right_joint_5"
     type="revolute">
     <origin
       xyz="1.6127E-05 0.0231 -0.2"
       rpy="0 0 0" />
     <parent
-      link="leg_r4_link" />
+      link="leg_right_link_4" />
     <child
-      link="leg_r5_link" />
+      link="leg_right_link_5" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -956,7 +956,7 @@
   </joint>
   
     <!-- ===== Right leg extra joints for 6 & 7 ===== -->
-  <link name="leg_r6_link">
+  <link name="leg_right_link_6">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <mass value="0.01"/>
@@ -965,15 +965,15 @@
     <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></visual>
     <collision><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></collision>
   </link>
-  <joint name="leg_r6_joint" type="revolute">
+  <joint name="leg_right_joint_6" type="revolute">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-    <parent link="leg_r5_link"/>
-    <child  link="leg_r6_link"/>
+    <parent link="leg_right_link_5"/>
+    <child  link="leg_right_link_6"/>
     <axis xyz="0 1 0"/>
     <limit lower="-1.57" upper="1.57" effort="26" velocity="10"/>
   </joint>
 
-  <link name="leg_r7_link">
+  <link name="leg_right_link_7">
     <inertial>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <mass value="0.01"/>
@@ -982,22 +982,22 @@
     <visual><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></visual>
     <collision><origin xyz="0 0 0" rpy="0 0 0"/><geometry><sphere radius="0.001"/></geometry></collision>
   </link>
-  <joint name="leg_r7_joint" type="revolute">
+  <joint name="leg_right_joint_7" type="revolute">
     <origin xyz="0 0 0" rpy="0 0 0"/>
-    <parent link="leg_r6_link"/>
-    <child  link="leg_r7_link"/>
+    <parent link="leg_right_link_6"/>
+    <child  link="leg_right_link_7"/>
     <axis xyz="0 1 0"/>
     <limit lower="-1.57" upper="1.57" effort="26" velocity="10"/>
   </joint>
 
 
 
-  <joint name="leg_r5_fixed_1" type="fixed">
+  <joint name="leg_right_fixed_1" type="fixed">
     <origin xyz="0.113 0.008 -0.006" rpy="0 0 0" />
-    <parent link="leg_r5_link" />
-    <child link="leg_r_f1_link" />
+    <parent link="leg_right_link_5" />
+    <child link="leg_right_f1_link" />
   </joint>
-  <link name="leg_r_f1_link">
+  <link name="leg_right_f1_link">
     <inertial>
       <mass value="0.01" />
       <inertia ixx="0.000001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.000001" />
@@ -1016,12 +1016,12 @@
     </collision>
   </link>
 
-  <joint name="leg_r5_fixed_2" type="fixed">
+  <joint name="leg_right_fixed_2" type="fixed">
     <origin xyz="-0.061 0.008 -0.006" rpy="0 0 0" />
-    <parent link="leg_r5_link" />
-    <child link="leg_r_f2_link" />
+    <parent link="leg_right_link_5" />
+    <child link="leg_right_f2_link" />
   </joint>
-  <link name="leg_r_f2_link">
+  <link name="leg_right_f2_link">
     <inertial>
       <mass value="0.01" />
       <inertia ixx="0.000001" ixy="0" ixz="0" iyy="0.000001" iyz="0" izz="0.000001" />
@@ -1042,27 +1042,27 @@
 
   
   
-    <gazebo reference="leg_r1_link">
+    <gazebo reference="leg_right_link_1">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_r2_link">
+  <gazebo reference="leg_right_link_2">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_r3_link">
+  <gazebo reference="leg_right_link_3">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_r4_link">
+  <gazebo reference="leg_right_link_4">
     <mu1>0.6</mu1>
     <mu2>0.6</mu2>
     <self_collide>1</self_collide>
   </gazebo>
-  <gazebo reference="leg_r5_link">
+  <gazebo reference="leg_right_link_5">
     <mu1>0.7</mu1>
     <mu2>0.7</mu2>
     <self_collide>1</self_collide>
@@ -1071,7 +1071,7 @@
     <maxVel>1.0</maxVel>
     <minDepth>0.00</minDepth>
   </gazebo>
-  <gazebo reference="leg_r_f1_link">
+  <gazebo reference="leg_right_f1_link">
     <mu1>1.5</mu1>
     <mu2>1.5</mu2>
     <self_collide>1</self_collide>
@@ -1080,7 +1080,7 @@
     <maxVel>1.0</maxVel>
     <minDepth>0.00</minDepth>
   </gazebo>
-  <gazebo reference="leg_r_f2_link">
+  <gazebo reference="leg_right_f2_link">
     <mu1>1.5</mu1>
     <mu2>1.5</mu2>
     <self_collide>1</self_collide>
@@ -1090,12 +1090,12 @@
     <minDepth>0.00</minDepth>
   </gazebo>
 
-  <transmission name="leg_r1_tran">
+  <transmission name="leg_right_tran_1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r1_joint">
+    <joint name="leg_right_joint_1">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r1_motor">
+    <actuator name="leg_right_motor_1">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
       	  <maxVelocity>1.484</maxVelocity><!-- 85rpm -->
@@ -1103,12 +1103,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_r2_tran">
+  <transmission name="leg_right_tran_2">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r2_joint">
+    <joint name="leg_right_joint_2">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r2_motor">
+    <actuator name="leg_right_motor_2">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
       	  <maxVelocity>2.6545</maxVelocity><!-- 160rpm -->
@@ -1116,12 +1116,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_r3_tran">
+  <transmission name="leg_right_tran_3">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r3_joint">
+    <joint name="leg_right_joint_3">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r3_motor">
+    <actuator name="leg_right_motor_3">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
       	  <maxVelocity>2.6545</maxVelocity><!-- 160rpm -->
@@ -1129,12 +1129,12 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_r4_tran">
+  <transmission name="leg_right_tran_4">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r4_joint">
+    <joint name="leg_right_joint_4">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r4_motor">
+    <actuator name="leg_right_motor_4">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
       	  <maxVelocity>1.484</maxVelocity><!-- 85rpm -->
@@ -1142,33 +1142,33 @@
     </actuator>
   </transmission>
 
-  <transmission name="leg_r5_tran">
+  <transmission name="leg_right_tran_5">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r5_joint">
+    <joint name="leg_right_joint_5">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r5_motor">
+    <actuator name="leg_right_motor_5">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
-    <transmission name="leg_r6_tran">
+    <transmission name="leg_right_tran_6">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r6_joint">
+    <joint name="leg_right_joint_6">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r6_motor">
+    <actuator name="leg_right_motor_6">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>
   </transmission>
 
-  <transmission name="leg_r7_tran">
+  <transmission name="leg_right_tran_7">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="leg_r7_joint">
+    <joint name="leg_right_joint_7">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     </joint>
-    <actuator name="leg_r7_motor">
+    <actuator name="leg_right_motor_7">
       <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
       <mechanicalReduction>1</mechanicalReduction>
     </actuator>

--- a/src/legged_examples/legged_dm_hw/config/dm.yaml
+++ b/src/legged_examples/legged_dm_hw/config/dm.yaml
@@ -3,6 +3,19 @@ cycle_time_error_threshold: 0.002
 thread_priority: 95
 power_limit: 6
 contact_threshold: 200
-joint_names: [leg_l1_joint, leg_l2_joint, leg_l3_joint, leg_l4_joint, leg_l5_joint, leg_l6_joint, leg_l7_joint,
-              leg_r1_joint, leg_r2_joint, leg_r3_joint, leg_r4_joint, leg_r5_joint, leg_r6_joint, leg_r7_joint]
 
+joint_modules:
+  - name: leg_left
+    enabled: true
+    joints: [leg_left_joint_1, leg_left_joint_2, leg_left_joint_3, leg_left_joint_4, leg_left_joint_5, leg_left_joint_6, leg_left_joint_7]
+    directions: [1, 1, -1, 1, 1, -1, 1]
+  - name: leg_right
+    enabled: true
+    joints: [leg_right_joint_1, leg_right_joint_2, leg_right_joint_3, leg_right_joint_4, leg_right_joint_5, leg_right_joint_6, leg_right_joint_7]
+    directions: [-1, -1, -1, 1, 1, -1, 1]
+
+# 扁平化后的数据，便于其它节点读取
+joint_names: [leg_left_joint_1, leg_left_joint_2, leg_left_joint_3, leg_left_joint_4, leg_left_joint_5, leg_left_joint_6, leg_left_joint_7,
+              leg_right_joint_1, leg_right_joint_2, leg_right_joint_3, leg_right_joint_4, leg_right_joint_5, leg_right_joint_6, leg_right_joint_7]
+joint_directions: [1, 1, -1, 1, 1, -1, 1,
+                   -1, -1, -1, 1, 1, -1, 1]

--- a/src/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
+++ b/src/legged_examples/legged_dm_hw/launch/legged_dm_hw.launch
@@ -9,9 +9,9 @@
         <!-- <param name="legged_robot_description" command="$(find wanren_arm)/urdf/wanren_arm.urdf"/> -->
         <param name="manual_topic_override" value="true"/>
         <param name="manual_cmd_timeout" value="0.2"/>
-        <rosparam file="$(find legged_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+        <rosparam file="$(find legged_dm_hw)/config/$(arg robot_type).yaml" command="load" ns="legged_dm_hw"/>
 
-        <node name="legged_dm_hw" pkg="legged_dm_hw" type="legged_dm_hw" respawn="false" clear_params="true" output="screen">
+        <node name="legged_dm_hw" pkg="legged_dm_hw" type="legged_dm_hw" respawn="false" output="screen">
         </node>
 
       <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen"   respawn="true" respawn_delay="0.002" >

--- a/src/legged_examples/legged_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/legged_dm_hw/src/DmHW.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <XmlRpcValue.h>
 
 namespace legged
 {
@@ -36,10 +37,13 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
     return false;
 
   robot_hw_nh.getParam("power_limit", powerLimit_);
-  robot_hw_nh.getParam("joint_names", configuredJointNames_);
+
+  if (!loadJointConfiguration(robot_hw_nh))
+    return false;
 
   // 注册关节、IMU句柄
-  setupJoints();
+  if (!setupJoints())
+    return false;
   setupImu();
 
   // 可选的状态与命令回显（不强制）
@@ -59,11 +63,11 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
 
 void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
 {
-  // 从下位机读 10 路电机
+  // 从下位机读取关节
   double pos, vel, tau;
-  for (int i=0; i< NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
-    motorsInterface->get_motor_data(pos, vel, tau, i);
+    motorsInterface->get_motor_data(pos, vel, tau, static_cast<int>(i));
     jointData_[i].pos_ = pos * directionMotor_[i];
     jointData_[i].vel_ = vel * directionMotor_[i];
     jointData_[i].tau_ = tau * directionMotor_[i];
@@ -94,8 +98,8 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
     use_manual = alive && !emergency_stop_;
   }
 
-  // 生成要下发的10路命令
-  for (int i = 0; i < NUM_JOINTS; ++i)
+  // 生成要下发的关节命令
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     double pos_des, vel_des, kp, kd, ff;
 
@@ -126,77 +130,42 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
   }
 
   // 写入下位机
-  for (int i = 0; i < NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     motorsInterface->fresh_cmd_motor_data(dmSendcmd_[i].pos_des_,
                                           dmSendcmd_[i].vel_des_,
                                           dmSendcmd_[i].ff_,
                                           dmSendcmd_[i].kp_,
-                                          dmSendcmd_[i].kd_, i);
+                                          dmSendcmd_[i].kd_, static_cast<int>(i));
   }
   motorsInterface->send_motor_data();
 
   // 简单回显（可选）
   std_msgs::Float64MultiArray a;
-  a.data.resize(NUM_JOINTS);
-  for (int i=0;i<NUM_JOINTS;++i) a.data[i] = dmSendcmd_[i].pos_des_;
+  a.data.resize(numJoints_);
+  for (size_t i = 0; i < numJoints_; ++i) a.data[i] = dmSendcmd_[i].pos_des_;
   cmd_pos_pub_.publish(a);
 }
 
 bool DmHW::setupJoints()
 {
-  if (!configuredJointNames_.empty())
+  if (jointNames_.empty())
   {
-    if (configuredJointNames_.size() != NUM_JOINTS)
+    ROS_ERROR("[DmHW] No joints configured. Set 'joint_modules' or 'joint_names'.");
+    return false;
+  }
+
+  for (size_t index = 0; index < jointNames_.size(); ++index)
+  {
+    const auto& name = jointNames_[index];
+    if (!urdfModel_->getJoint(name))
     {
-      ROS_ERROR("[DmHW] joint_names param expects %d entries, got %zu", NUM_JOINTS, configuredJointNames_.size());
+      ROS_ERROR("[DmHW] Joint '%s' from configuration not found in URDF", name.c_str());
       return false;
     }
 
-    for (size_t index = 0; index < configuredJointNames_.size(); ++index)
-    {
-      const auto& name = configuredJointNames_[index];
-      if (!urdfModel_->getJoint(name))
-      {
-        ROS_ERROR("[DmHW] Joint '%s' from joint_names param not found in URDF", name.c_str());
-        return false;
-      }
-
-      hardware_interface::JointStateHandle state_handle(
-        name, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
-      jointStateInterface_.registerHandle(state_handle);
-
-      hybridJointInterface_.registerHandle(HybridJointHandle(
-        state_handle,
-        &jointData_[index].pos_des_, &jointData_[index].vel_des_,
-        &jointData_[index].kp_, &jointData_[index].kd_, &jointData_[index].ff_));
-    }
-
-    ROS_INFO_STREAM("[DmHW] Registered joints from parameter joint_names.");
-    return true;
-  }
-
-  const int JOINTS_PER_LEG = 7;
-  for (const auto& joint : urdfModel_->joints_)
-  {
-    int leg_index=-1, joint_index=-1;
-    if (joint.first.find("leg_l") != std::string::npos)      leg_index = 0;
-    else if (joint.first.find("leg_r") != std::string::npos) leg_index = 1;
-    else continue;
-
-    if      (joint.first.find("1_joint") != std::string::npos) joint_index = 0;
-    else if (joint.first.find("2_joint") != std::string::npos) joint_index = 1;
-    else if (joint.first.find("3_joint") != std::string::npos) joint_index = 2;
-    else if (joint.first.find("4_joint") != std::string::npos) joint_index = 3;
-    else if (joint.first.find("5_joint") != std::string::npos) joint_index = 4;
-    else if (joint.first.find("6_joint") != std::string::npos) joint_index = 5; // 新增
-    else if (joint.first.find("7_joint") != std::string::npos) joint_index = 6; // 新增
-    else continue;
-
-    int index = leg_index * JOINTS_PER_LEG + joint_index;
-
     hardware_interface::JointStateHandle state_handle(
-      joint.first, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
+      name, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
     jointStateInterface_.registerHandle(state_handle);
 
     hybridJointInterface_.registerHandle(HybridJointHandle(
@@ -204,7 +173,163 @@ bool DmHW::setupJoints()
       &jointData_[index].pos_des_, &jointData_[index].vel_des_,
       &jointData_[index].kp_, &jointData_[index].kd_, &jointData_[index].ff_));
   }
+
+  ROS_INFO_STREAM("[DmHW] Registered " << jointNames_.size() << " joints.");
   return true;
+}
+
+bool DmHW::loadJointConfiguration(const ros::NodeHandle& robot_hw_nh)
+{
+  jointNames_.clear();
+  directionMotor_.clear();
+
+  if (!flattenJointModules(robot_hw_nh, jointNames_, directionMotor_))
+  {
+    robot_hw_nh.getParam("joint_names", jointNames_);
+    robot_hw_nh.getParam("joint_directions", directionMotor_);
+  }
+
+  if (jointNames_.empty())
+  {
+    ROS_ERROR("[DmHW] Parameters 'joint_modules' or 'joint_names' must provide at least one joint.");
+    return false;
+  }
+
+  numJoints_ = jointNames_.size();
+
+  if (!directionMotor_.empty() && directionMotor_.size() != numJoints_)
+  {
+    ROS_ERROR("[DmHW] joint_directions size (%zu) does not match joint count (%zu).",
+              directionMotor_.size(), numJoints_);
+    return false;
+  }
+
+  if (directionMotor_.empty())
+  {
+    directionMotor_.assign(numJoints_, 1);
+  }
+
+  jointData_.assign(numJoints_, {});
+  dmSendcmd_.assign(numJoints_, {});
+  cmd_pos_.assign(numJoints_, 0.0);
+  cmd_vel_.assign(numJoints_, 0.0);
+  cmd_kp_.assign(numJoints_, 0.0);
+  cmd_kd_.assign(numJoints_, 0.0);
+  cmd_tau_.assign(numJoints_, 0.0);
+
+  ROS_INFO_STREAM("[DmHW] Loaded joint configuration with " << numJoints_ << " entries.");
+  return true;
+}
+
+bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
+                               std::vector<std::string>& names,
+                               std::vector<int>& directions) const
+{
+  XmlRpc::XmlRpcValue modules;
+  if (!robot_hw_nh.getParam("joint_modules", modules))
+    return false;
+
+  if (modules.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  {
+    ROS_ERROR("[DmHW] Parameter 'joint_modules' must be a list.");
+    return false;
+  }
+
+  for (int i = 0; i < modules.size(); ++i)
+  {
+    if (modules[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      ROS_WARN("[DmHW] joint_modules[%d] is not a struct, skipping.", i);
+      continue;
+    }
+
+    const auto& module = modules[i];
+    bool enabled = true;
+    if (module.hasMember("enabled"))
+    {
+      try
+      {
+        enabled = static_cast<bool>(module["enabled"]);
+      }
+      catch (const XmlRpc::XmlRpcException&)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true.", i);
+      }
+    }
+    if (!enabled)
+      continue;
+
+    if (!module.hasMember("joints"))
+    {
+      ROS_WARN("[DmHW] joint_modules[%d] missing 'joints', skipping.", i);
+      continue;
+    }
+
+    const auto& joint_list = module["joints"];
+    if (joint_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    {
+      ROS_WARN("[DmHW] joint_modules[%d].joints must be a list, skipping.", i);
+      continue;
+    }
+
+    std::vector<int> moduleDirections;
+    if (module.hasMember("directions"))
+    {
+      const auto& dir_list = module["directions"];
+      if (dir_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].directions must be a list, ignoring.", i);
+      }
+      else
+      {
+        moduleDirections.reserve(dir_list.size());
+        for (int j = 0; j < dir_list.size(); ++j)
+        {
+          try
+          {
+            moduleDirections.push_back(static_cast<int>(dir_list[j]));
+          }
+          catch (const XmlRpc::XmlRpcException&)
+          {
+            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1.", i, j);
+            moduleDirections.push_back(1);
+          }
+        }
+      }
+    }
+
+    for (int j = 0; j < joint_list.size(); ++j)
+    {
+      try
+      {
+        const std::string joint_name = static_cast<std::string>(joint_list[j]);
+        names.push_back(joint_name);
+        if (!moduleDirections.empty())
+        {
+          if (static_cast<size_t>(j) < moduleDirections.size())
+            directions.push_back(moduleDirections[j]);
+          else
+            directions.push_back(moduleDirections.back());
+        }
+        else
+        {
+          directions.push_back(1);
+        }
+      }
+      catch (const XmlRpc::XmlRpcException&)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry.", i, j);
+      }
+    }
+  }
+
+  // Remove trailing directions if we appended defaults for skipped joints.
+  if (directions.size() != names.size())
+  {
+    directions.resize(names.size(), 1);
+  }
+
+  return !names.empty();
 }
 
 bool DmHW::setupImu()
@@ -222,19 +347,19 @@ bool DmHW::setupImu()
 
 void DmHW::hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg)
 {
-  if (msg->data.size() != 5 * NUM_JOINTS) {
-    ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%dpos+%dvel+%dkp+%dkd+%dtau)，当前=%zu",
-                    5ul*NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS,
+  if (msg->data.size() != 5 * numJoints_) {
+    ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%zupos+%zuvel+%zukp+%zukd+%zutau)，当前=%zu",
+                    5ull * numJoints_, numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
                     msg->data.size());
     return;
   }
   std::lock_guard<std::mutex> lk(cmd_mtx_);
   const auto& d = msg->data;
-  for (int i=0;i<NUM_JOINTS;++i) cmd_pos_[i] = d[0*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_vel_[i] = d[1*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_kp_[i]  = d[2*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_kd_[i]  = d[3*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_tau_[i] = d[4*NUM_JOINTS + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_pos_[i] = d[0 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_vel_[i] = d[1 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_kp_[i]  = d[2 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_kd_[i]  = d[3 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_tau_[i] = d[4 * numJoints_ + i];
 
   last_cmd_stamp_ = ros::Time::now();
 }

--- a/src/legged_examples/neck_dm_hw/config/dm.yaml
+++ b/src/legged_examples/neck_dm_hw/config/dm.yaml
@@ -3,9 +3,21 @@ cycle_time_error_threshold: 0.002
 thread_priority: 95
 power_limit: 6
 contact_threshold: 200
-# 关节索引 -> 实际电机 CAN ID 映射（-1 表示禁用该关节）。默认保持 0..13 顺序，可按需修改。
-motor_id_map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
-joint_names: [neck_left_joint_1, neck_left_joint_2, neck_left_joint_3, neck_left_joint_4, neck_left_joint_5, neck_left_joint_6,
-              neck_left_joint_7, neck_right_joint_1, neck_right_joint_2, neck_right_joint_3, neck_right_joint_4,
-              neck_right_joint_5, neck_right_joint_6, neck_right_joint_7]
 
+joint_modules:
+  - name: neck_left
+    enabled: true
+    joints: [neck_left_joint_1, neck_left_joint_2, neck_left_joint_3, neck_left_joint_4, neck_left_joint_5, neck_left_joint_6, neck_left_joint_7]
+    directions: [1, 1, -1, 1, 1, -1, 1]
+  - name: neck_right
+    enabled: true
+    joints: [neck_right_joint_1, neck_right_joint_2, neck_right_joint_3, neck_right_joint_4, neck_right_joint_5, neck_right_joint_6, neck_right_joint_7]
+    directions: [-1, -1, -1, 1, 1, -1, 1]
+
+joint_names: [neck_left_joint_1, neck_left_joint_2, neck_left_joint_3, neck_left_joint_4, neck_left_joint_5, neck_left_joint_6, neck_left_joint_7,
+              neck_right_joint_1, neck_right_joint_2, neck_right_joint_3, neck_right_joint_4, neck_right_joint_5, neck_right_joint_6, neck_right_joint_7]
+joint_directions: [1, 1, -1, 1, 1, -1, 1,
+                   -1, -1, -1, 1, 1, -1, 1]
+
+# 关节索引 -> 实际电机 CAN ID 映射（-1 表示禁用该关节）。
+motor_id_map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]

--- a/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
+++ b/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
@@ -13,7 +13,6 @@
 #include <string>
 
 #include <memory>
-static constexpr int NUM_JOINTS = 14;
 namespace legged
 {
 
@@ -56,6 +55,10 @@ private:
   // 内部初始化
   bool setupJoints();
   bool setupImu();
+  bool loadJointConfiguration(const ros::NodeHandle& robot_hw_nh);
+  bool flattenJointModules(const ros::NodeHandle& robot_hw_nh,
+                           std::vector<std::string>& names,
+                           std::vector<int>& directions) const;
 
   // 话题覆盖回调
   void hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
@@ -70,34 +73,32 @@ private:
   ros::Subscriber hybrid_cmd_sub_, emg_sub_;
 
   // 设备与配置
-  DmMotorData jointData_[NUM_JOINTS]{};
+  std::vector<DmMotorData> jointData_;
   DmImuData imuData_{};
   int powerLimit_{0};
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
 
-  std::array<int, NUM_JOINTS> motorIdMap_{};
+  std::vector<int> motorIdMap_;
 
   // 下发缓冲（电机方向映射）
-  DmMotorData dmSendcmd_[NUM_JOINTS];
-  const std::vector<int> directionMotor_{
-    1, 1, -1, 1, 1,   -1, 1,    // 左腿 0..6
-    -1, -1, -1, 1, 1, -1, 1     // 右腿 7..13 例子，按需改
-  };
+  std::vector<DmMotorData> dmSendcmd_;
+  std::vector<int> directionMotor_;
+  size_t numJoints_{0};
 
   // Optional configuration to override the joint discovery order
-  std::vector<std::string> configuredJointNames_;
+  std::vector<std::string> jointNames_;
 
   // 外部IMU缓存
   sensor_msgs::Imu yesenceIMU_;
 
   // 手动覆盖相关
   std::mutex cmd_mtx_;
-  std::array<double,NUM_JOINTS> cmd_pos_{};
-  std::array<double,NUM_JOINTS> cmd_vel_{};
-  std::array<double,NUM_JOINTS> cmd_kp_{};
-  std::array<double,NUM_JOINTS> cmd_kd_{};
-  std::array<double,NUM_JOINTS> cmd_tau_{};
+  std::vector<double> cmd_pos_;
+  std::vector<double> cmd_vel_;
+  std::vector<double> cmd_kp_;
+  std::vector<double> cmd_kd_;
+  std::vector<double> cmd_tau_;
   ros::Time last_cmd_stamp_;
   bool emergency_stop_{false};
   bool manual_override_{false};

--- a/src/legged_examples/neck_dm_hw/launch/neck_dm_hw.launch
+++ b/src/legged_examples/neck_dm_hw/launch/neck_dm_hw.launch
@@ -7,9 +7,9 @@
             robot_type:=$(arg robot_type) "/>
         <param name="manual_topic_override" value="true"/>
         <param name="manual_cmd_timeout" value="0.2"/>
-        <rosparam file="$(find neck_dm_hw)/config/$(arg robot_type).yaml" command="load"/>
+        <rosparam file="$(find neck_dm_hw)/config/$(arg robot_type).yaml" command="load" ns="neck_dm_hw"/>
 
-        <node name="neck_dm_hw" pkg="neck_dm_hw" type="neck_dm_hw" respawn="false" clear_params="true" output="screen">
+        <node name="neck_dm_hw" pkg="neck_dm_hw" type="neck_dm_hw" respawn="false" output="screen">
         </node>
 
       <!--<node pkg="yesense_imu" type="yesense_imu_node" name="yesense_imu_node" output="screen"   respawn="true" respawn_delay="0.002" >

--- a/src/legged_examples/neck_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/neck_dm_hw/src/DmHW.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
+#include <XmlRpcValue.h>
 
 namespace legged
 {
@@ -37,12 +38,15 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
     return false;
 
   robot_hw_nh.getParam("power_limit", powerLimit_);
-  robot_hw_nh.getParam("joint_names", configuredJointNames_);
+
+  if (!loadJointConfiguration(robot_hw_nh))
+    return false;
 
   loadMotorIdMap(robot_hw_nh);
 
   // 注册关节、IMU句柄
-  setupJoints();
+  if (!setupJoints())
+    return false;
   setupImu();
 
   // 可选的状态与命令回显（不强制）
@@ -62,12 +66,12 @@ bool DmHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh)
 
 void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
 {
-  // 从下位机读 10 路电机
+  // 从下位机读取关节
   double pos, vel, tau;
-  for (int i=0; i< NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     const int motor_idx = motorIdMap_[i];
-    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    if (motor_idx < 0 || static_cast<size_t>(motor_idx) >= numJoints_)
     {
       jointData_[i].pos_ = 0.0;
       jointData_[i].vel_ = 0.0;
@@ -107,7 +111,7 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
   }
 
   // 生成要下发的 N 路命令
-  for (int i = 0; i < NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     double pos_des, vel_des, kp, kd, ff;
 
@@ -130,10 +134,10 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
     }
 
     const int motor_idx = motorIdMap_[i];
-    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    if (motor_idx < 0 || static_cast<size_t>(motor_idx) >= numJoints_)
     {
       ROS_WARN_THROTTLE(5.0,
-        "[Neck] Joint %d disabled by motor_id_map, skip command.", i);
+        "[Neck] Joint %zu disabled by motor_id_map, skip command.", i);
       dmSendcmd_[i].pos_des_ = 0.0;
       dmSendcmd_[i].vel_des_ = 0.0;
       dmSendcmd_[i].kp_      = 0.0;
@@ -144,7 +148,7 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
 
     // ⭐ 在这里加日志，打印 controller 写进来的数据
     ROS_INFO_THROTTLE(1.0,
-      "[Neck] Pre-map Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f (manual=%d)",
+      "[Neck] Pre-map Joint[%zu->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f (manual=%d)",
       i, motor_idx, pos_des, vel_des, kp, kd, ff, use_manual);
 
     // 关节→电机 方向映射
@@ -156,16 +160,16 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
 
     // ⭐ 再加一层，确认映射后的数据
     ROS_INFO_THROTTLE(1.0,
-      "[Neck] Mapped  Joint[%d->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f",
+      "[Neck] Mapped  Joint[%zu->motor %d]: pos=%.3f vel=%.3f kp=%.2f kd=%.2f ff=%.3f",
       i, motor_idx, dmSendcmd_[i].pos_des_, dmSendcmd_[i].vel_des_, dmSendcmd_[i].kp_,
       dmSendcmd_[i].kd_, dmSendcmd_[i].ff_);
   }
 
   // 写入下位机
-  for (int i = 0; i < NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     const int motor_idx = motorIdMap_[i];
-    if (motor_idx < 0 || motor_idx >= NUM_JOINTS)
+    if (motor_idx < 0 || static_cast<size_t>(motor_idx) >= numJoints_)
       continue;
 
     motorsInterface->fresh_cmd_motor_data(dmSendcmd_[i].pos_des_,
@@ -175,28 +179,184 @@ void DmHW::write(const ros::Time& time, const ros::Duration& /*period*/)
                                           dmSendcmd_[i].kd_, motor_idx);
   }
   motorsInterface->send_motor_data();
+
+  std_msgs::Float64MultiArray a;
+  a.data.resize(numJoints_);
+  for (size_t i = 0; i < numJoints_; ++i)
+    a.data[i] = dmSendcmd_[i].pos_des_;
+  cmd_pos_pub_.publish(a);
+}
+
+bool DmHW::loadJointConfiguration(const ros::NodeHandle& robot_hw_nh)
+{
+  jointNames_.clear();
+  directionMotor_.clear();
+
+  if (!flattenJointModules(robot_hw_nh, jointNames_, directionMotor_))
+  {
+    robot_hw_nh.getParam("joint_names", jointNames_);
+    robot_hw_nh.getParam("joint_directions", directionMotor_);
+  }
+
+  if (jointNames_.empty())
+  {
+    ROS_ERROR("[DmHW] Parameters 'joint_modules' or 'joint_names' must provide at least one joint.");
+    return false;
+  }
+
+  numJoints_ = jointNames_.size();
+
+  if (!directionMotor_.empty() && directionMotor_.size() != numJoints_)
+  {
+    ROS_ERROR("[DmHW] joint_directions size (%zu) does not match joint count (%zu).",
+              directionMotor_.size(), numJoints_);
+    return false;
+  }
+
+  if (directionMotor_.empty())
+    directionMotor_.assign(numJoints_, 1);
+
+  jointData_.assign(numJoints_, {});
+  dmSendcmd_.assign(numJoints_, {});
+  cmd_pos_.assign(numJoints_, 0.0);
+  cmd_vel_.assign(numJoints_, 0.0);
+  cmd_kp_.assign(numJoints_, 0.0);
+  cmd_kd_.assign(numJoints_, 0.0);
+  cmd_tau_.assign(numJoints_, 0.0);
+
+  ROS_INFO_STREAM("[DmHW] Loaded joint configuration with " << numJoints_ << " entries.");
+  return true;
+}
+
+bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
+                               std::vector<std::string>& names,
+                               std::vector<int>& directions) const
+{
+  XmlRpc::XmlRpcValue modules;
+  if (!robot_hw_nh.getParam("joint_modules", modules))
+    return false;
+
+  if (modules.getType() != XmlRpc::XmlRpcValue::TypeArray)
+  {
+    ROS_ERROR("[DmHW] Parameter 'joint_modules' must be a list.");
+    return false;
+  }
+
+  for (int i = 0; i < modules.size(); ++i)
+  {
+    if (modules[i].getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      ROS_WARN("[DmHW] joint_modules[%d] is not a struct, skipping.", i);
+      continue;
+    }
+
+    const auto& module = modules[i];
+    bool enabled = true;
+    if (module.hasMember("enabled"))
+    {
+      try
+      {
+        enabled = static_cast<bool>(module["enabled"]);
+      }
+      catch (const XmlRpc::XmlRpcException&)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true.", i);
+      }
+    }
+    if (!enabled)
+      continue;
+
+    if (!module.hasMember("joints"))
+    {
+      ROS_WARN("[DmHW] joint_modules[%d] missing 'joints', skipping.", i);
+      continue;
+    }
+
+    const auto& joint_list = module["joints"];
+    if (joint_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+    {
+      ROS_WARN("[DmHW] joint_modules[%d].joints must be a list, skipping.", i);
+      continue;
+    }
+
+    std::vector<int> moduleDirections;
+    if (module.hasMember("directions"))
+    {
+      const auto& dir_list = module["directions"];
+      if (dir_list.getType() != XmlRpc::XmlRpcValue::TypeArray)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].directions must be a list, ignoring.", i);
+      }
+      else
+      {
+        moduleDirections.reserve(dir_list.size());
+        for (int j = 0; j < dir_list.size(); ++j)
+        {
+          try
+          {
+            moduleDirections.push_back(static_cast<int>(dir_list[j]));
+          }
+          catch (const XmlRpc::XmlRpcException&)
+          {
+            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1.", i, j);
+            moduleDirections.push_back(1);
+          }
+        }
+      }
+    }
+
+    for (int j = 0; j < joint_list.size(); ++j)
+    {
+      try
+      {
+        const std::string joint_name = static_cast<std::string>(joint_list[j]);
+        names.push_back(joint_name);
+        if (!moduleDirections.empty())
+        {
+          if (static_cast<size_t>(j) < moduleDirections.size())
+            directions.push_back(moduleDirections[j]);
+          else
+            directions.push_back(moduleDirections.back());
+        }
+        else
+        {
+          directions.push_back(1);
+        }
+      }
+      catch (const XmlRpc::XmlRpcException&)
+      {
+        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry.", i, j);
+      }
+    }
+  }
+
+  if (directions.size() != names.size())
+    directions.resize(names.size(), 1);
+
+  return !names.empty();
 }
 
 void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
 {
-  for (int i = 0; i < NUM_JOINTS; ++i)
-    motorIdMap_[i] = i;
+  motorIdMap_.resize(numJoints_);
+  for (size_t i = 0; i < numJoints_; ++i)
+    motorIdMap_[i] = static_cast<int>(i);
 
   std::vector<int> motor_ids;
   if (!robot_hw_nh.getParam("motor_id_map", motor_ids))
   {
-    ROS_INFO("[DmHW] '~motor_id_map' not set, using default 0..%d", NUM_JOINTS - 1);
+    ROS_INFO("[DmHW] '~motor_id_map' not set, using default 0..%zu", numJoints_ ? numJoints_ - 1 : 0);
     return;
   }
 
-  if (motor_ids.size() != NUM_JOINTS)
+  if (motor_ids.size() != numJoints_)
   {
-    ROS_WARN("[DmHW] '~motor_id_map' size=%zu, expected %d. Keep default mapping.",
-             motor_ids.size(), NUM_JOINTS);
+    ROS_WARN("[DmHW] '~motor_id_map' size=%zu, expected %zu. Keep default mapping.",
+             motor_ids.size(), numJoints_);
     return;
   }
 
-  std::array<bool, NUM_JOINTS> used{};
+  std::vector<bool> used(numJoints_, false);
   for (size_t i = 0; i < motor_ids.size(); ++i)
   {
     int id = motor_ids[i];
@@ -206,20 +366,20 @@ void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
       continue;
     }
 
-    if (id < 0 || id >= NUM_JOINTS)
+    if (id < 0 || static_cast<size_t>(id) >= numJoints_)
     {
-      ROS_WARN("[DmHW] motor_id_map[%zu]=%d out of range [0,%d]. Revert to default mapping.",
-               i, id, NUM_JOINTS - 1);
-      for (int j = 0; j < NUM_JOINTS; ++j)
-        motorIdMap_[j] = j;
+      ROS_WARN("[DmHW] motor_id_map[%zu]=%d out of range [0,%zu]. Revert to default mapping.",
+               i, id, numJoints_ ? numJoints_ - 1 : 0);
+      for (size_t j = 0; j < numJoints_; ++j)
+        motorIdMap_[j] = static_cast<int>(j);
       return;
     }
 
     if (used[id])
     {
       ROS_WARN("[DmHW] motor_id_map contains duplicate id %d. Revert to default mapping.", id);
-      for (int j = 0; j < NUM_JOINTS; ++j)
-        motorIdMap_[j] = j;
+      for (size_t j = 0; j < numJoints_; ++j)
+        motorIdMap_[j] = static_cast<int>(j);
       return;
     }
 
@@ -228,7 +388,7 @@ void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
   }
 
   std::ostringstream oss;
-  for (int i = 0; i < NUM_JOINTS; ++i)
+  for (size_t i = 0; i < numJoints_; ++i)
   {
     if (i)
       oss << ", ";
@@ -239,58 +399,23 @@ void DmHW::loadMotorIdMap(const ros::NodeHandle& robot_hw_nh)
 
 bool DmHW::setupJoints()
 {
-  if (!configuredJointNames_.empty())
+  if (jointNames_.empty())
   {
-    if (configuredJointNames_.size() != NUM_JOINTS)
+    ROS_ERROR("[DmHW] No joints configured. Set 'joint_modules' or 'joint_names'.");
+    return false;
+  }
+
+  for (size_t index = 0; index < jointNames_.size(); ++index)
+  {
+    const auto& name = jointNames_[index];
+    if (!urdfModel_->getJoint(name))
     {
-      ROS_ERROR("[DmHW] joint_names param expects %d entries, got %zu", NUM_JOINTS, configuredJointNames_.size());
+      ROS_ERROR("[DmHW] Joint '%s' from configuration not found in URDF", name.c_str());
       return false;
     }
 
-    for (size_t index = 0; index < configuredJointNames_.size(); ++index)
-    {
-      const auto& name = configuredJointNames_[index];
-      if (!urdfModel_->getJoint(name))
-      {
-        ROS_ERROR("[DmHW] Joint '%s' from joint_names param not found in URDF", name.c_str());
-        return false;
-      }
-
-      hardware_interface::JointStateHandle state_handle(
-        name, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
-      jointStateInterface_.registerHandle(state_handle);
-
-      hybridJointInterface_.registerHandle(HybridJointHandle(
-        state_handle,
-        &jointData_[index].pos_des_, &jointData_[index].vel_des_,
-        &jointData_[index].kp_, &jointData_[index].kd_, &jointData_[index].ff_));
-    }
-
-    ROS_INFO_STREAM("[DmHW] Registered joints from parameter joint_names.");
-    return true;
-  }
-
-  const int JOINTS_PER_LEG = 7;
-  for (const auto& joint : urdfModel_->joints_)
-  {
-    int leg_index=-1, joint_index=-1;
-    if (joint.first.find("neck_l") != std::string::npos)      leg_index = 0;
-    else if (joint.first.find("neck_r") != std::string::npos) leg_index = 1;
-    else continue;
-
-    if      (joint.first.find("1_joint") != std::string::npos) joint_index = 0;
-    else if (joint.first.find("2_joint") != std::string::npos) joint_index = 1;
-    else if (joint.first.find("3_joint") != std::string::npos) joint_index = 2;
-    else if (joint.first.find("4_joint") != std::string::npos) joint_index = 3;
-    else if (joint.first.find("5_joint") != std::string::npos) joint_index = 4;
-    else if (joint.first.find("6_joint") != std::string::npos) joint_index = 5; // 新增
-    else if (joint.first.find("7_joint") != std::string::npos) joint_index = 6; // 新增
-    else continue;
-
-    int index = leg_index * JOINTS_PER_LEG + joint_index;
-
     hardware_interface::JointStateHandle state_handle(
-      joint.first, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
+      name, &jointData_[index].pos_, &jointData_[index].vel_, &jointData_[index].tau_);
     jointStateInterface_.registerHandle(state_handle);
 
     hybridJointInterface_.registerHandle(HybridJointHandle(
@@ -298,6 +423,8 @@ bool DmHW::setupJoints()
       &jointData_[index].pos_des_, &jointData_[index].vel_des_,
       &jointData_[index].kp_, &jointData_[index].kd_, &jointData_[index].ff_));
   }
+
+  ROS_INFO_STREAM("[DmHW] Registered " << jointNames_.size() << " joints.");
   return true;
 }
 
@@ -316,19 +443,19 @@ bool DmHW::setupImu()
 
 void DmHW::hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg)
 {
-  if (msg->data.size() != 5 * NUM_JOINTS) {
-    ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%dpos+%dvel+%dkp+%dkd+%dtau)，当前=%zu",
-                    5ul*NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS, NUM_JOINTS,
+  if (msg->data.size() != 5 * numJoints_) {
+    ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%zupos+%zuvel+%zukp+%zukd+%zutau)，当前=%zu",
+                    5ull * numJoints_, numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
                     msg->data.size());
     return;
   }
   std::lock_guard<std::mutex> lk(cmd_mtx_);
   const auto& d = msg->data;
-  for (int i=0;i<NUM_JOINTS;++i) cmd_pos_[i] = d[0*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_vel_[i] = d[1*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_kp_[i]  = d[2*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_kd_[i]  = d[3*NUM_JOINTS + i];
-  for (int i=0;i<NUM_JOINTS;++i) cmd_tau_[i] = d[4*NUM_JOINTS + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_pos_[i] = d[0 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_vel_[i] = d[1 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_kp_[i]  = d[2 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_kd_[i]  = d[3 * numJoints_ + i];
+  for (size_t i = 0; i < numJoints_; ++i) cmd_tau_[i] = d[4 * numJoints_ + i];
 
   last_cmd_stamp_ = ros::Time::now();
 }

--- a/src/right_arm_hw/config/controllers.yaml
+++ b/src/right_arm_hw/config/controllers.yaml
@@ -4,7 +4,7 @@ joint_state_controller:
 
 right_arm_controller:
   type: "joint_trajectory_controller/JointTrajectoryController"
-  joints: ['leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
+  joints: ['leg_right_joint_1','leg_right_joint_2','leg_right_joint_3','leg_right_joint_4','leg_right_joint_5','leg_right_joint_6','leg_right_joint_7']
   constraints:
     goal_time: 1.0
   state_publish_rate: 100

--- a/src/right_arm_hw/config/moveit_controllers.yaml
+++ b/src/right_arm_hw/config/moveit_controllers.yaml
@@ -4,10 +4,10 @@ controller_list:
     type: FollowJointTrajectory
     default: true
     joints:
-      - leg_r1_joint
-      - leg_r2_joint
-      - leg_r3_joint
-      - leg_r4_joint
-      - leg_r5_joint
-      - leg_r6_joint
-      - leg_r7_joint
+      - leg_right_joint_1
+      - leg_right_joint_2
+      - leg_right_joint_3
+      - leg_right_joint_4
+      - leg_right_joint_5
+      - leg_right_joint_6
+      - leg_right_joint_7

--- a/src/right_arm_hw/launch/bringup.launch
+++ b/src/right_arm_hw/launch/bringup.launch
@@ -8,7 +8,7 @@
       <!-- 如需改成你控制器实际订阅的话题，在此重映射 -->
       <remap from="command_moveJ" to="/all_joints_hjc/command_moveJ"/>
       <!-- 若要显式指定关节名顺序（不指定则用默认）：
-      <param name="joint_names" value="['leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']"/>
+      <param name="joint_names" value="['leg_right_joint_1','leg_right_joint_2','leg_right_joint_3','leg_right_joint_4','leg_right_joint_5','leg_right_joint_6','leg_right_joint_7']"/>
       -->
     </node>
   </group>

--- a/src/right_arm_hw/src/ftj_to_moveJ_bridge.cpp
+++ b/src/right_arm_hw/src/ftj_to_moveJ_bridge.cpp
@@ -13,8 +13,8 @@
 #include <cmath>
 
 static const std::vector<std::string> kRightJointsDefault = {
-  "leg_r1_joint","leg_r2_joint","leg_r3_joint",
-  "leg_r4_joint","leg_r5_joint","leg_r6_joint","leg_r7_joint"
+  "leg_right_joint_1","leg_right_joint_2","leg_right_joint_3",
+  "leg_right_joint_4","leg_right_joint_5","leg_right_joint_6","leg_right_joint_7"
 };
 
 class FtjToMoveJBridge

--- a/src/right_arm_moveit_config/config/fake_controllers.yaml
+++ b/src/right_arm_moveit_config/config/fake_controllers.yaml
@@ -2,13 +2,13 @@ controller_list:
   - name: fake_right_arm_controller
     type: $(arg fake_execution_type)
     joints:
-      - leg_r1_joint
-      - leg_r2_joint
-      - leg_r3_joint
-      - leg_r4_joint
-      - leg_r5_joint
-      - leg_r6_joint
-      - leg_r7_joint
+      - leg_right_joint_1
+      - leg_right_joint_2
+      - leg_right_joint_3
+      - leg_right_joint_4
+      - leg_right_joint_5
+      - leg_right_joint_6
+      - leg_right_joint_7
 initial:  # Define initial robot poses per group
 #  - group: right_arm
 #    pose: home

--- a/src/right_arm_moveit_config/config/gazebo_wanren_arm.urdf
+++ b/src/right_arm_moveit_config/config/gazebo_wanren_arm.urdf
@@ -3,7 +3,7 @@
      Commit Version: 1.6.0-4-g7f85cfe  Build Version: 1.6.7995.38578
      For more information, please see http://wiki.ros.org/sw_urdf_exporter -->
 <robot name="wanren_arm">
-    <link name="body">
+    <link name="torso_link">
         <inertial>
             <origin xyz="1.58624299813302E-05 2.01332320114156E-07 -0.0245724500252954" rpy="0 0 0" />
             <mass value="0.60016209200883" />
@@ -25,7 +25,7 @@
             </geometry>
         </collision>
     </link>
-    <link name="leg_r1_link">
+    <link name="leg_right_link_1">
         <inertial>
             <origin xyz="-0.00382422792815949 -0.0123142355221975 0.0766747228132015" rpy="0 0 0" />
             <mass value="0.292899916417866" />
@@ -47,13 +47,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r1_joint" type="continuous">
+    <joint name="leg_right_joint_1" type="continuous">
         <origin xyz="0 0 0.011999999999999" rpy="0 0 0" />
-        <parent link="body" />
-        <child link="leg_r1_link" />
+        <parent link="torso_link" />
+        <child link="leg_right_link_1" />
         <axis xyz="0 0 -1" />
     </joint>
-    <link name="leg_r2_link">
+    <link name="leg_right_link_2">
         <inertial>
             <origin xyz="0.0284932164900757 0.0852314382000906 0.0233442478183801" rpy="0 0 0" />
             <mass value="0.118782011304387" />
@@ -75,13 +75,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r2_joint" type="continuous">
+    <joint name="leg_right_joint_2" type="continuous">
         <origin xyz="-0.0136812977041495 -0.0436944371355362 0.0808116620061236" rpy="0 0 0" />
-        <parent link="leg_r1_link" />
-        <child link="leg_r2_link" />
+        <parent link="leg_right_link_1" />
+        <child link="leg_right_link_2" />
         <axis xyz="0.29752487908452 0.954714065218347 0" />
     </joint>
-    <link name="leg_r3_link">
+    <link name="leg_right_link_3">
         <inertial>
             <origin xyz="0.00440804925886197 -0.000927955750798931 0.0105438054247052" rpy="0 0 0" />
             <mass value="0.395227613542105" />
@@ -103,13 +103,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r3_joint" type="continuous">
+    <joint name="leg_right_joint_3" type="continuous">
         <origin xyz="0.0412068272569313 0.104588881771451 0.106228185949221" rpy="0 0 0" />
-        <parent link="leg_r2_link" />
-        <child link="leg_r3_link" />
+        <parent link="leg_right_link_2" />
+        <child link="leg_right_link_3" />
         <axis xyz="-0.0722349306802614 0.022511126419206 -0.997133573788866" />
     </joint>
-    <link name="leg_r4_link">
+    <link name="leg_right_link_4">
         <inertial>
             <origin xyz="0.0155060558890136 0.0411774297341984 0.0346709586399187" rpy="0 0 0" />
             <mass value="0.0222841339329651" />
@@ -131,13 +131,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r4_joint" type="continuous">
+    <joint name="leg_right_joint_4" type="continuous">
         <origin xyz="-0.00228042956033238 -0.0297792321778995 0.0833604475054363" rpy="0 0 0" />
-        <parent link="leg_r3_link" />
-        <child link="leg_r4_link" />
+        <parent link="leg_right_link_3" />
+        <child link="leg_right_link_4" />
         <axis xyz="0.282983296167026 0.959124144572578 0.0011529910516605" />
     </joint>
-    <link name="leg_r5_link">
+    <link name="leg_right_link_5">
         <inertial>
             <origin xyz="-0.0048559147531092 -0.0119363039004067 -0.00678188706287566" rpy="0 0 0" />
             <mass value="0.38824624930896" />
@@ -159,13 +159,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r5_joint" type="continuous">
+    <joint name="leg_right_joint_5" type="continuous">
         <origin xyz="0.0181511434262854 0.025007599076044 0.111134888878763" rpy="0 1.26722046551249 0" />
-        <parent link="leg_r4_link" />
-        <child link="leg_r5_link" />
+        <parent link="leg_right_link_4" />
+        <child link="leg_right_link_5" />
         <axis xyz="0.923719785557326 0.0273056458564005 -0.382094437900229" />
     </joint>
-    <link name="leg_r6_link">
+    <link name="leg_right_link_6">
         <inertial>
             <origin xyz="0.0651691107467127 0.0806102275858783 -0.0545046281847596" rpy="0 0 0" />
             <mass value="0.174871084341935" />
@@ -187,13 +187,13 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r6_joint" type="continuous">
+    <joint name="leg_right_joint_6" type="continuous">
         <origin xyz="-0.0550712045826083 -0.0332459772838745 -0.000878918231283499" rpy="1.5372364468678 -1.26722046551249 0" />
-        <parent link="leg_r5_link" />
-        <child link="leg_r6_link" />
+        <parent link="leg_right_link_5" />
+        <child link="leg_right_link_6" />
         <axis xyz="0.565655964466871 0 -0.824641334073823" />
     </joint>
-    <link name="leg_r7_link">
+    <link name="leg_right_link_7">
         <inertial>
             <origin xyz="0.122014637753753 -0.108460665221082 -0.0505526819127103" rpy="0 0 0" />
             <mass value="0.784412251530751" />
@@ -215,78 +215,78 @@
             </geometry>
         </collision>
     </link>
-    <joint name="leg_r7_joint" type="continuous">
+    <joint name="leg_right_joint_7" type="continuous">
         <origin xyz="0.0506954674848457 0.0975609362242854 -0.0679978120533321" rpy="-1.5372364468678 0 0" />
-        <parent link="leg_r6_link" />
-        <child link="leg_r7_link" />
+        <parent link="leg_right_link_6" />
+        <child link="leg_right_link_7" />
         <axis xyz="0.804819794366103 -0.559061164385712 -0.199288015375224" />
     </joint>
-    <transmission name="trans_leg_r1_joint">
+    <transmission name="trans_leg_right_joint_1">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r1_joint">
+        <joint name="leg_right_joint_1">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r1_joint_motor">
+        <actuator name="leg_right_joint_1_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r2_joint">
+    <transmission name="trans_leg_right_joint_2">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r2_joint">
+        <joint name="leg_right_joint_2">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r2_joint_motor">
+        <actuator name="leg_right_joint_2_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r3_joint">
+    <transmission name="trans_leg_right_joint_3">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r3_joint">
+        <joint name="leg_right_joint_3">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r3_joint_motor">
+        <actuator name="leg_right_joint_3_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r4_joint">
+    <transmission name="trans_leg_right_joint_4">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r4_joint">
+        <joint name="leg_right_joint_4">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r4_joint_motor">
+        <actuator name="leg_right_joint_4_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r5_joint">
+    <transmission name="trans_leg_right_joint_5">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r5_joint">
+        <joint name="leg_right_joint_5">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r5_joint_motor">
+        <actuator name="leg_right_joint_5_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r6_joint">
+    <transmission name="trans_leg_right_joint_6">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r6_joint">
+        <joint name="leg_right_joint_6">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r6_joint_motor">
+        <actuator name="leg_right_joint_6_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>
     </transmission>
-    <transmission name="trans_leg_r7_joint">
+    <transmission name="trans_leg_right_joint_7">
         <type>transmission_interface/SimpleTransmission</type>
-        <joint name="leg_r7_joint">
+        <joint name="leg_right_joint_7">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
         </joint>
-        <actuator name="leg_r7_joint_motor">
+        <actuator name="leg_right_joint_7_motor">
             <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
             <mechanicalReduction>1</mechanicalReduction>
         </actuator>

--- a/src/right_arm_moveit_config/config/joint_limits.yaml
+++ b/src/right_arm_moveit_config/config/joint_limits.yaml
@@ -8,37 +8,37 @@ default_acceleration_scaling_factor: 0.1
 # Specific joint properties can be changed with the keys [max_position, min_position, max_velocity, max_acceleration]
 # Joint limits can be turned off with [has_velocity_limits, has_acceleration_limits]
 joint_limits:
-  leg_r1_joint:
+  leg_right_joint_1:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r2_joint:
+  leg_right_joint_2:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r3_joint:
+  leg_right_joint_3:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r4_joint:
+  leg_right_joint_4:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r5_joint:
+  leg_right_joint_5:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r6_joint:
+  leg_right_joint_6:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false
     max_acceleration: 0
-  leg_r7_joint:
+  leg_right_joint_7:
     has_velocity_limits: false
     max_velocity: 0
     has_acceleration_limits: false

--- a/src/right_arm_moveit_config/config/moveit_controller.yaml
+++ b/src/right_arm_moveit_config/config/moveit_controller.yaml
@@ -6,10 +6,10 @@ arm_controller:
   type: FollowJointTrajectory
   default: true
   joints:
-    - leg_r1_joint
-    - leg_r2_joint
-    - leg_r3_joint
-    - leg_r4_joint
-    - leg_r5_joint
-    - leg_r6_joint
-    - leg_r7_joint
+    - leg_right_joint_1
+    - leg_right_joint_2
+    - leg_right_joint_3
+    - leg_right_joint_4
+    - leg_right_joint_5
+    - leg_right_joint_6
+    - leg_right_joint_7

--- a/src/right_arm_moveit_config/config/ompl_planning.yaml
+++ b/src/right_arm_moveit_config/config/ompl_planning.yaml
@@ -194,5 +194,5 @@ right_arm:
     - AITstar
     - ABITstar
     - BITstar
-  projection_evaluator: joints(leg_r1_joint,leg_r2_joint)
+  projection_evaluator: joints(leg_right_joint_1,leg_right_joint_2)
   longest_valid_segment_fraction: 0.005

--- a/src/right_arm_moveit_config/config/ros_controllers.yaml
+++ b/src/right_arm_moveit_config/config/ros_controllers.yaml
@@ -1,45 +1,45 @@
 right_arm_controller:
   type: effort_controllers/JointTrajectoryController
   joints:
-    - leg_r1_joint
-    - leg_r2_joint
-    - leg_r3_joint
-    - leg_r4_joint
-    - leg_r5_joint
-    - leg_r6_joint
-    - leg_r7_joint
+    - leg_right_joint_1
+    - leg_right_joint_2
+    - leg_right_joint_3
+    - leg_right_joint_4
+    - leg_right_joint_5
+    - leg_right_joint_6
+    - leg_right_joint_7
   gains:
-    leg_r1_joint:
+    leg_right_joint_1:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r2_joint:
+    leg_right_joint_2:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r3_joint:
+    leg_right_joint_3:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r4_joint:
+    leg_right_joint_4:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r5_joint:
+    leg_right_joint_5:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r6_joint:
+    leg_right_joint_6:
       p: 100
       d: 1
       i: 1
       i_clamp: 1
-    leg_r7_joint:
+    leg_right_joint_7:
       p: 100
       d: 1
       i: 1

--- a/src/right_arm_moveit_config/config/simple_moveit_controllers.yaml
+++ b/src/right_arm_moveit_config/config/simple_moveit_controllers.yaml
@@ -4,10 +4,10 @@ controller_list:
     type: FollowJointTrajectory
     default: True
     joints:
-      - leg_r1_joint
-      - leg_r2_joint
-      - leg_r3_joint
-      - leg_r4_joint
-      - leg_r5_joint
-      - leg_r6_joint
-      - leg_r7_joint
+      - leg_right_joint_1
+      - leg_right_joint_2
+      - leg_right_joint_3
+      - leg_right_joint_4
+      - leg_right_joint_5
+      - leg_right_joint_6
+      - leg_right_joint_7

--- a/src/right_arm_moveit_config/config/wanren_arm.srdf
+++ b/src/right_arm_moveit_config/config/wanren_arm.srdf
@@ -10,7 +10,7 @@
     <!--CHAINS: When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS: Groups can also be formed by referencing to already defined group names-->
     <group name="right_arm">
-        <chain base_link="body" tip_link="leg_r7_link"/>
+        <chain base_link="torso_link" tip_link="leg_right_link_7"/>
     </group>
     <!--VIRTUAL JOINT: Purpose: this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <virtual_joint name="base" type="fixed" parent_frame="base" child_link="body"/>

--- a/src/right_arm_moveit_config/launch/demo.launch
+++ b/src/right_arm_moveit_config/launch/demo.launch
@@ -24,7 +24,7 @@
   <arg name="use_rviz" default="true" />
 
   <!-- If needed, broadcast static tf for robot root -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 base body" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="virtual_joint_broadcaster_0" args="0 0 0 0 0 0 base torso_link" />
 
   <group if="$(eval arg('moveit_controller_manager') == 'fake')">
     <!-- We do not have a real robot connected, so publish fake joint states via a joint_state_publisher

--- a/src/right_arm_moveit_config/launch/moveit.rviz
+++ b/src/right_arm_moveit_config/launch/moveit.rviz
@@ -80,7 +80,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: body
+    Fixed Frame: torso_link
   Name: root
   Tools:
     - Class: rviz/Interact
@@ -108,7 +108,7 @@ Visualization Manager:
       Name: Current View
       Near Clip Distance: 0.01
       Pitch: 0.5
-      Target Frame: body
+      Target Frame: torso_link
       Yaw: -0.6232355833053589
     Saved: ~
 Window Geometry:

--- a/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller/src/AllJointsHybridController.cpp
@@ -6,8 +6,8 @@ namespace simple_hjc {
 
 // 如果未在参数里给 joints，就按这个默认（可改成 14 路）
 static const std::vector<std::string> kDefaultJointNames = {
-  "leg_l1_joint","leg_l2_joint","leg_l3_joint","leg_l4_joint","leg_l5_joint","leg_l6_joint","leg_l7_joint",
-  "leg_r1_joint","leg_r2_joint","leg_r3_joint","leg_r4_joint","leg_r5_joint","leg_r6_joint","leg_r7_joint"
+  "leg_left_joint_1","leg_left_joint_2","leg_left_joint_3","leg_left_joint_4","leg_left_joint_5","leg_left_joint_6","leg_left_joint_7",
+  "leg_right_joint_1","leg_right_joint_2","leg_right_joint_3","leg_right_joint_4","leg_right_joint_5","leg_right_joint_6","leg_right_joint_7"
 };
 
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {

--- a/src/simple_hybrid_joint_controller_leg/launch/bringup_real.launch
+++ b/src/simple_hybrid_joint_controller_leg/launch/bringup_real.launch
@@ -19,8 +19,8 @@
 
     <rosparam param="all_joints_hjc_leg">
       type: simple_hjc/AllJointsHybridController
-      joints: ['leg_l1_joint','leg_l2_joint','leg_l3_joint','leg_l4_joint','leg_l5_joint','leg_l6_joint','leg_l7_joint',
-               'leg_r1_joint','leg_r2_joint','leg_r3_joint','leg_r4_joint','leg_r5_joint','leg_r6_joint','leg_r7_joint']
+      joints: ['leg_left_joint_1','leg_left_joint_2','leg_left_joint_3','leg_left_joint_4','leg_left_joint_5','leg_left_joint_6','leg_left_joint_7',
+               'leg_right_joint_1','leg_right_joint_2','leg_right_joint_3','leg_right_joint_4','leg_right_joint_5','leg_right_joint_6','leg_right_joint_7']
       default_kp: 20.0
       default_kd: 1.0
       default_vel: 0.0

--- a/src/simple_hybrid_joint_controller_leg/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_leg/src/AllJointsHybridController.cpp
@@ -6,8 +6,8 @@ namespace simple_hjc {
 
 // 如果未在参数里给 joints，就按这个默认（可改成 14 路）
 static const std::vector<std::string> kDefaultJointNames = {
-  "leg_l1_joint","leg_l2_joint","leg_l3_joint","leg_l4_joint","leg_l5_joint","leg_l6_joint","leg_l7_joint",
-  "leg_r1_joint","leg_r2_joint","leg_r3_joint","leg_r4_joint","leg_r5_joint","leg_r6_joint","leg_r7_joint"
+  "leg_left_joint_1","leg_left_joint_2","leg_left_joint_3","leg_left_joint_4","leg_left_joint_5","leg_left_joint_6","leg_left_joint_7",
+  "leg_right_joint_1","leg_right_joint_2","leg_right_joint_3","leg_right_joint_4","leg_right_joint_5","leg_right_joint_6","leg_right_joint_7"
 };
 
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {

--- a/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
+++ b/src/simple_hybrid_joint_controller_neck/src/AllJointsHybridController.cpp
@@ -14,8 +14,8 @@ static const std::vector<std::string> kDefaultJointNames = {
 
 
 // static const std::vector<std::string> kDefaultJointNames = {
-//   "leg_l1_joint","leg_l2_joint","leg_l3_joint","leg_l4_joint","leg_l5_joint","leg_l6_joint","leg_l7_joint",
-//   "leg_r1_joint","leg_r2_joint","leg_r3_joint","leg_r4_joint","leg_r5_joint","leg_r6_joint","leg_r7_joint"
+//   "leg_left_joint_1","leg_left_joint_2","leg_left_joint_3","leg_left_joint_4","leg_left_joint_5","leg_left_joint_6","leg_left_joint_7",
+//   "leg_right_joint_1","leg_right_joint_2","leg_right_joint_3","leg_right_joint_4","leg_right_joint_5","leg_right_joint_6","leg_right_joint_7"
 // };
 bool AllJointsHybridController::init(legged::HybridJointInterface* hw, ros::NodeHandle& nh) {
   // 关节列表：从参数读取；没有就用默认（建议在 launch 里明确传入 14 个）

--- a/src/wanren_arm/config/joint_names_urdf6.yaml
+++ b/src/wanren_arm/config/joint_names_urdf6.yaml
@@ -1,1 +1,1 @@
-controller_joint_names: ['', 'leg_r1_joint', 'leg_r2_joint', 'leg_r3_joint', 'leg_r4_joint', 'leg_r5_joint', 'leg_r6_joint', 'leg_r7_joint', ]
+controller_joint_names: ['', 'leg_right_joint_1', 'leg_right_joint_2', 'leg_right_joint_3', 'leg_right_joint_4', 'leg_right_joint_5', 'leg_right_joint_6', 'leg_right_joint_7', ]

--- a/src/wanren_arm/config/wanren_controllers.yaml
+++ b/src/wanren_arm/config/wanren_controllers.yaml
@@ -4,14 +4,14 @@ legs:
     publish_rate: 200
   legs_left_controller:
     type: simple_hjc/AllJointsHybridController
-    joints: [leg_l1_joint, leg_l2_joint, leg_l3_joint, leg_l4_joint, leg_l5_joint, leg_l6_joint, leg_l7_joint]
+    joints: [leg_left_joint_1, leg_left_joint_2, leg_left_joint_3, leg_left_joint_4, leg_left_joint_5, leg_left_joint_6, leg_left_joint_7]
     default_kp: 20.0
     default_kd: 1.0
     default_vel: 0.0
     default_ff: 0.0
   legs_right_controller:
     type: simple_hjc/AllJointsHybridController
-    joints: [leg_r1_joint, leg_r2_joint, leg_r3_joint, leg_r4_joint, leg_r5_joint, leg_r6_joint, leg_r7_joint]
+    joints: [leg_right_joint_1, leg_right_joint_2, leg_right_joint_3, leg_right_joint_4, leg_right_joint_5, leg_right_joint_6, leg_right_joint_7]
     default_kp: 20.0
     default_kd: 1.0
     default_vel: 0.0
@@ -50,6 +50,18 @@ neck:
   neck_right_controller:
     type: simple_hjc/AllJointsHybridController
     joints: [neck_right_joint_1, neck_right_joint_2, neck_right_joint_3, neck_right_joint_4, neck_right_joint_5, neck_right_joint_6, neck_right_joint_7]
+    default_kp: 20.0
+    default_kd: 1.0
+    default_vel: 0.0
+    default_ff: 0.0
+
+waist:
+  joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 200
+  waist_controller:
+    type: simple_hjc/AllJointsHybridController
+    joints: [waist_yaw_joint]
     default_kp: 20.0
     default_kd: 1.0
     default_vel: 0.0

--- a/src/wanren_arm/urdf/wanren_arm.urdf
+++ b/src/wanren_arm/urdf/wanren_arm.urdf
@@ -1,13 +1,72 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- This URDF was automatically created by SolidWorks to URDF Exporter! Originally created by Stephen Brawner (brawner@gmail.com) 
-     Commit Version: 1.6.0-4-g7f85cfe  Build Version: 1.6.7995.38578
-     For more information, please see http://wiki.ros.org/sw_urdf_exporter -->
-<robot
-  name="wanren_arm">
-  <!-- Add a dummy link to handle inertia -->
+<!-- Modularized version of the original Wanren humanoid description. -->
+<robot name="wanren_arm" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <xacro:arg name="enable_waist" default="true" />
+  <xacro:arg name="enable_neck_left" default="true" />
+  <xacro:arg name="enable_neck_right" default="true" />
+  <xacro:arg name="enable_arm_left" default="true" />
+  <xacro:arg name="enable_arm_right" default="true" />
+  <xacro:arg name="enable_leg_left" default="true" />
+  <xacro:arg name="enable_leg_right" default="true" />
 
+  <!-- Base reference link -->
+  <link name="base_link">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <mass value="0.001" />
+      <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+    </inertial>
+  </link>
+
+  <xacro:if value="${enable_waist}">
+    <link name="waist_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <mass value="0.05" />
+        <inertia ixx="1e-4" ixy="0" ixz="0" iyy="1e-4" iyz="0" izz="1e-4" />
+      </inertial>
+      <visual>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <cylinder radius="0.08" length="0.05" />
+        </geometry>
+        <material name="waist_material">
+          <color rgba="0.5 0.5 0.5 1" />
+        </material>
+      </visual>
+      <collision>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <geometry>
+          <cylinder radius="0.08" length="0.05" />
+        </geometry>
+      </collision>
+    </link>
+
+    <joint name="waist_yaw_joint" type="continuous">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="base_link" />
+      <child link="waist_link" />
+      <axis xyz="0 0 1" />
+    </joint>
+
+    <joint name="waist_to_torso_fixed" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="waist_link" />
+      <child link="torso_link" />
+    </joint>
+  </xacro:if>
+
+  <xacro:unless value="${enable_waist}">
+    <joint name="base_to_torso_fixed" type="fixed">
+      <origin xyz="0 0 0" rpy="0 0 0" />
+      <parent link="base_link" />
+      <child link="torso_link" />
+    </joint>
+  </xacro:unless>
+
+  <!-- Add a dummy link to handle inertia -->
   <link
-    name="body">
+    name="torso_link">
     <inertial>
       <origin
         xyz="1.58624299813302E-05 2.01332320114156E-07 -0.0245724500252954"
@@ -46,8 +105,9 @@
       </geometry>
     </collision>
   </link>
+  <xacro:if value="${enable_leg_right}">
   <link
-    name="leg_r1_link">
+    name="leg_right_link_1">
     <inertial>
       <origin
         xyz="-0.00382422792815949 -0.0123142355221975 0.0766747228132015"
@@ -87,20 +147,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r1_joint"
+    name="leg_right_joint_1"
     type="continuous">
     <origin
       xyz="0 0 0.011999999999999"
       rpy="0 0 0" />
     <parent
-      link="body" />
+      link="torso_link" />
     <child
-      link="leg_r1_link" />
+      link="leg_right_link_1" />
     <axis
       xyz="0 0 -1" />
   </joint>
   <link
-    name="leg_r2_link">
+    name="leg_right_link_2">
     <inertial>
       <origin
         xyz="0.0284932164900757 0.0852314382000906 0.0233442478183801"
@@ -140,20 +200,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r2_joint"
+    name="leg_right_joint_2"
     type="continuous">
     <origin
       xyz="-0.0136812977041495 -0.0436944371355362 0.0808116620061236"
       rpy="0 0 0" />
     <parent
-      link="leg_r1_link" />
+      link="leg_right_link_1" />
     <child
-      link="leg_r2_link" />
+      link="leg_right_link_2" />
     <axis
       xyz="0.29752487908452 0.954714065218347 0" />
   </joint>
   <link
-    name="leg_r3_link">
+    name="leg_right_link_3">
     <inertial>
       <origin
         xyz="0.00440804925886197 -0.000927955750798931 0.0105438054247052"
@@ -193,20 +253,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r3_joint"
+    name="leg_right_joint_3"
     type="continuous">
     <origin
       xyz="0.0412068272569313 0.104588881771451 0.106228185949221"
       rpy="0 0 0" />
     <parent
-      link="leg_r2_link" />
+      link="leg_right_link_2" />
     <child
-      link="leg_r3_link" />
+      link="leg_right_link_3" />
     <axis
       xyz="-0.0722349306802614 0.022511126419206 -0.997133573788866" />
   </joint>
   <link
-    name="leg_r4_link">
+    name="leg_right_link_4">
     <inertial>
       <origin
         xyz="0.0155060558890136 0.0411774297341984 0.0346709586399187"
@@ -246,20 +306,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r4_joint"
+    name="leg_right_joint_4"
     type="continuous">
     <origin
       xyz="-0.00228042956033238 -0.0297792321778995 0.0833604475054363"
       rpy="0 0 0" />
     <parent
-      link="leg_r3_link" />
+      link="leg_right_link_3" />
     <child
-      link="leg_r4_link" />
+      link="leg_right_link_4" />
     <axis
       xyz="0.282983296167026 0.959124144572578 0.0011529910516605" />
   </joint>
   <link
-    name="leg_r5_link">
+    name="leg_right_link_5">
     <inertial>
       <origin
         xyz="-0.0048559147531092 -0.0119363039004067 -0.00678188706287566"
@@ -299,20 +359,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r5_joint"
+    name="leg_right_joint_5"
     type="continuous">
     <origin
       xyz="0.0181511434262854 0.025007599076044 0.111134888878763"
       rpy="0 1.26722046551249 0" />
     <parent
-      link="leg_r4_link" />
+      link="leg_right_link_4" />
     <child
-      link="leg_r5_link" />
+      link="leg_right_link_5" />
     <axis
       xyz="0.923719785557326 0.0273056458564005 -0.382094437900229" />
   </joint>
   <link
-    name="leg_r6_link">
+    name="leg_right_link_6">
     <inertial>
       <origin
         xyz="0.0651691107467127 0.0806102275858783 -0.0545046281847596"
@@ -352,20 +412,20 @@
     </collision>
   </link>
   <joint
-    name="leg_r6_joint"
+    name="leg_right_joint_6"
     type="continuous">
     <origin
       xyz="-0.0550712045826083 -0.0332459772838745 -0.000878918231283499"
       rpy="1.5372364468678 -1.26722046551249 0" />
     <parent
-      link="leg_r5_link" />
+      link="leg_right_link_5" />
     <child
-      link="leg_r6_link" />
+      link="leg_right_link_6" />
     <axis
       xyz="0.565655964466871 0 -0.824641334073823" />
   </joint>
   <link
-    name="leg_r7_link">
+    name="leg_right_link_7">
     <inertial>
       <origin
         xyz="0.122014637753753 -0.108460665221082 -0.0505526819127103"
@@ -394,21 +454,22 @@
     </collision>
   </link>
   <joint
-    name="leg_r7_joint"
+    name="leg_right_joint_7"
     type="continuous">
     <origin
       xyz="0.0506954674848457 0.0975609362242854 -0.0679978120533321"
       rpy="-1.5372364468678 0 0" />
     <parent
-      link="leg_r6_link" />
+      link="leg_right_link_6" />
     <child
-      link="leg_r7_link" />
+      link="leg_right_link_7" />
     <axis
       xyz="0.804819794366103 -0.559061164385712 -0.199288015375224" />
   </joint>
 
 
   <!-- Added neck and arm kinematics -->
+  <xacro:if value="${enable_neck_left or enable_neck_right}">
   <!-- Neck base -->
   <link name="neck_mount_link">
     <inertial>
@@ -434,9 +495,10 @@
   </link>
   <joint name="neck_mount_fixed" type="fixed">
     <origin xyz="0 0 0.45" rpy="0 0 0"/>
-    <parent link="body"/>
+    <parent link="torso_link"/>
     <child link="neck_mount_link"/>
   </joint>
+  <xacro:if value="${enable_neck_left}">
   <link name="neck_left_link_1">
     <inertial>
       <origin xyz="0 0 0.040" rpy="0 0 0"/>
@@ -633,6 +695,7 @@
     <child link="neck_left_link_7"/>
     <axis xyz="1 0 0"/>
   </joint>
+  <xacro:if value="${enable_neck_right}">
   <link name="neck_right_link_1">
     <inertial>
       <origin xyz="0 0 0.040" rpy="0 0 0"/>
@@ -829,6 +892,7 @@
     <child link="neck_right_link_7"/>
     <axis xyz="1 0 0"/>
   </joint>
+  <xacro:if value="${enable_arm_left}">
   <link name="arm_left_link_1">
     <inertial>
       <origin xyz="0 0 0.090" rpy="0 0 0"/>
@@ -985,7 +1049,7 @@
   </link>
   <joint name="arm_left_joint_1" type="continuous">
     <origin xyz="0.050 0.250 0.250" rpy="0 0 0"/>
-    <parent link="body"/>
+    <parent link="torso_link"/>
     <child link="arm_left_link_1"/>
     <axis xyz="0 0 1"/>
   </joint>
@@ -1025,6 +1089,7 @@
     <child link="arm_left_link_7"/>
     <axis xyz="0 1 0"/>
   </joint>
+  <xacro:if value="${enable_arm_right}">
   <link name="arm_right_link_1">
     <inertial>
       <origin xyz="0 0 0.090" rpy="0 0 0"/>
@@ -1181,7 +1246,7 @@
   </link>
   <joint name="arm_right_joint_1" type="continuous">
     <origin xyz="0.050 -0.250 0.250" rpy="0 0 0"/>
-    <parent link="body"/>
+    <parent link="torso_link"/>
     <child link="arm_right_link_1"/>
     <axis xyz="0 0 1"/>
   </joint>
@@ -1222,84 +1287,86 @@
     <axis xyz="0 1 0"/>
   </joint>
 
-  <transmission name="trans_leg_r1">
+  <transmission name="trans_leg_right_1">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r1">
+  <actuator name="motor_leg_right_1">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r1_joint">
+  <joint name="leg_right_joint_1">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r2">
+  <transmission name="trans_leg_right_2">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r2">
+  <actuator name="motor_leg_right_2">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r2_joint">
+  <joint name="leg_right_joint_2">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r3">
+  <transmission name="trans_leg_right_3">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r3">
+  <actuator name="motor_leg_right_3">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r3_joint">
+  <joint name="leg_right_joint_3">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r4">
+  <transmission name="trans_leg_right_4">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r4">
+  <actuator name="motor_leg_right_4">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r4_joint">
+  <joint name="leg_right_joint_4">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r5">
+  <transmission name="trans_leg_right_5">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r5">
+  <actuator name="motor_leg_right_5">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r5_joint">
+  <joint name="leg_right_joint_5">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r6">
+  <transmission name="trans_leg_right_6">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r6">
+  <actuator name="motor_leg_right_6">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r6_joint">
+  <joint name="leg_right_joint_6">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_r7">
+  <transmission name="trans_leg_right_7">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_r7">
+  <actuator name="motor_leg_right_7">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_r7_joint">
+  <joint name="leg_right_joint_7">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
+  </xacro:if>
+  <xacro:if value="${enable_leg_left}">
   <link
-    name="leg_l1_link">
+    name="leg_left_link_1">
     <inertial>
       <origin
         xyz="-0.00382422792815949 -0.0123142355221975 0.0766747228132015"
@@ -1339,20 +1406,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l1_joint"
+    name="leg_left_joint_1"
     type="continuous">
     <origin
       xyz="1 1 -0.011999999999999"
       rpy="0 0 0" />
     <parent
-      link="body" />
+      link="torso_link" />
     <child
-      link="leg_l1_link" />
+      link="leg_left_link_1" />
     <axis
       xyz="0 0 -1" />
   </joint>
   <link
-    name="leg_l2_link">
+    name="leg_left_link_2">
     <inertial>
       <origin
         xyz="0.0284932164900757 0.0852314382000906 0.0233442478183801"
@@ -1392,20 +1459,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l2_joint"
+    name="leg_left_joint_2"
     type="continuous">
     <origin
       xyz="-0.0136812977041495 -0.0436944371355362 0.0808116620061236"
       rpy="0 0 0" />
     <parent
-      link="leg_l1_link" />
+      link="leg_left_link_1" />
     <child
-      link="leg_l2_link" />
+      link="leg_left_link_2" />
     <axis
       xyz="0.29752487908452 0.954714065218347 0" />
   </joint>
   <link
-    name="leg_l3_link">
+    name="leg_left_link_3">
     <inertial>
       <origin
         xyz="0.00440804925886197 -0.000927955750798931 0.0105438054247052"
@@ -1445,20 +1512,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l3_joint"
+    name="leg_left_joint_3"
     type="continuous">
     <origin
       xyz="0.0412068272569313 0.104588881771451 0.106228185949221"
       rpy="0 0 0" />
     <parent
-      link="leg_l2_link" />
+      link="leg_left_link_2" />
     <child
-      link="leg_l3_link" />
+      link="leg_left_link_3" />
     <axis
       xyz="-0.0722349306802614 0.022511126419206 -0.997133573788866" />
   </joint>
   <link
-    name="leg_l4_link">
+    name="leg_left_link_4">
     <inertial>
       <origin
         xyz="0.0155060558890136 0.0411774297341984 0.0346709586399187"
@@ -1498,20 +1565,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l4_joint"
+    name="leg_left_joint_4"
     type="continuous">
     <origin
       xyz="-0.00228042956033238 -0.0297792321778995 0.0833604475054363"
       rpy="0 0 0" />
     <parent
-      link="leg_l3_link" />
+      link="leg_left_link_3" />
     <child
-      link="leg_l4_link" />
+      link="leg_left_link_4" />
     <axis
       xyz="0.282983296167026 0.959124144572578 0.0011529910516605" />
   </joint>
   <link
-    name="leg_l5_link">
+    name="leg_left_link_5">
     <inertial>
       <origin
         xyz="-0.0048559147531092 -0.0119363039004067 -0.00678188706287566"
@@ -1551,20 +1618,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l5_joint"
+    name="leg_left_joint_5"
     type="continuous">
     <origin
       xyz="0.0181511434262854 0.025007599076044 0.111134888878763"
       rpy="0 1.26722046551249 0" />
     <parent
-      link="leg_l4_link" />
+      link="leg_left_link_4" />
     <child
-      link="leg_l5_link" />
+      link="leg_left_link_5" />
     <axis
       xyz="0.923719785557326 0.0273056458564005 -0.382094437900229" />
   </joint>
   <link
-    name="leg_l6_link">
+    name="leg_left_link_6">
     <inertial>
       <origin
         xyz="0.0651691107467127 0.0806102275858783 -0.0545046281847596"
@@ -1604,20 +1671,20 @@
     </collision>
   </link>
   <joint
-    name="leg_l6_joint"
+    name="leg_left_joint_6"
     type="continuous">
     <origin
       xyz="-0.0550712045826083 -0.0332459772838745 -0.000878918231283499"
       rpy="1.5372364468678 -1.26722046551249 0" />
     <parent
-      link="leg_l5_link" />
+      link="leg_left_link_5" />
     <child
-      link="leg_l6_link" />
+      link="leg_left_link_6" />
     <axis
       xyz="0.565655964466871 0 -0.824641334073823" />
   </joint>
   <link
-    name="leg_l7_link">
+    name="leg_left_link_7">
     <inertial>
       <origin
         xyz="0.122014637753753 -0.108460665221082 -0.0505526819127103"
@@ -1646,95 +1713,97 @@
     </collision>
   </link>
   <joint
-    name="leg_l7_joint"
+    name="leg_left_joint_7"
     type="continuous">
     <origin
       xyz="0.0506954674848457 0.0975609362242854 -0.0679978120533321"
       rpy="-1.5372364468678 0 0" />
     <parent
-      link="leg_l6_link" />
+      link="leg_left_link_6" />
     <child
-      link="leg_l7_link" />
+      link="leg_left_link_7" />
     <axis
       xyz="0.804819794366103 -0.559061164385712 -0.199288015375224" />
   </joint>
 
-  <transmission name="trans_leg_l1">
+  <transmission name="trans_leg_left_1">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l1">
+  <actuator name="motor_leg_left_1">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l1_joint">
+  <joint name="leg_left_joint_1">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l2">
+  <transmission name="trans_leg_left_2">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l2">
+  <actuator name="motor_leg_left_2">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l2_joint">
+  <joint name="leg_left_joint_2">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l3">
+  <transmission name="trans_leg_left_3">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l3">
+  <actuator name="motor_leg_left_3">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l3_joint">
+  <joint name="leg_left_joint_3">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l4">
+  <transmission name="trans_leg_left_4">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l4">
+  <actuator name="motor_leg_left_4">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l4_joint">
+  <joint name="leg_left_joint_4">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l5">
+  <transmission name="trans_leg_left_5">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l5">
+  <actuator name="motor_leg_left_5">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l5_joint">
+  <joint name="leg_left_joint_5">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l6">
+  <transmission name="trans_leg_left_6">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l6">
+  <actuator name="motor_leg_left_6">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l6_joint">
+  <joint name="leg_left_joint_6">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
 
-  <transmission name="trans_leg_l7">
+  <transmission name="trans_leg_left_7">
   <type>transmission_interface/SimpleTransmission</type>
-  <actuator name="motor_leg_l7">
+  <actuator name="motor_leg_left_7">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
     <mechanicalReduction>1</mechanicalReduction>
   </actuator>
-  <joint name="leg_l7_joint">
+  <joint name="leg_left_joint_7">
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
+
+  </xacro:if>
 
   <transmission name="trans_neck_left_joint_1">
   <type>transmission_interface/SimpleTransmission</type>
@@ -1813,6 +1882,8 @@
   </joint>
   </transmission>
 
+  </xacro:if>
+
   <transmission name="trans_neck_right_joint_1">
   <type>transmission_interface/SimpleTransmission</type>
   <actuator name="motor_neck_right_joint_1">
@@ -1889,6 +1960,10 @@
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
+
+  </xacro:if>
+
+  </xacro:if>
 
   <transmission name="trans_arm_left_joint_1">
   <type>transmission_interface/SimpleTransmission</type>
@@ -1967,6 +2042,8 @@
   </joint>
   </transmission>
 
+  </xacro:if>
+
   <transmission name="trans_arm_right_joint_1">
   <type>transmission_interface/SimpleTransmission</type>
   <actuator name="motor_arm_right_joint_1">
@@ -2043,6 +2120,21 @@
     <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
   </joint>
   </transmission>
+
+  </xacro:if>
+
+  <xacro:if value="${enable_waist}">
+  <transmission name="trans_waist_yaw_joint">
+  <type>transmission_interface/SimpleTransmission</type>
+  <actuator name="motor_waist_yaw_joint">
+    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+    <mechanicalReduction>1</mechanicalReduction>
+  </actuator>
+  <joint name="waist_yaw_joint">
+    <hardwareInterface>hardware_interface/EffortJointInterface</hardwareInterface>
+  </joint>
+  </transmission>
+  </xacro:if>
 
 
 </robot>


### PR DESCRIPTION
## Summary
- convert both legged_dm_hw and neck_dm_hw hardware layers to load joint groups from reusable modules while keeping vector-based command buffers consistent with the URDF names
- refactor the Wanren URDF and controller configs so waist, neck, arms, and legs can be toggled independently with consistent joint naming across MoveIt, controllers, and hardware
- document the modular switches, update launch files to keep required parameters in the private namespace, and refresh README instructions for testing and troubleshooting

## Testing
- not run (workspace tooling not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68d62ea785c88323abf84a2335951e39