### PR TITLE
Fix XmlRpc exception handling and introduce ludan alias

### DIFF
--- a/src/legged_common/include/legged_common/namespaces.h
+++ b/src/legged_common/include/legged_common/namespaces.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Provide a project-wide namespace alias so code can use the robot specific
+// naming (`ludan`) while continuing to reuse the legacy implementation that
+// still lives in the `legged` namespace.
+//
+// Including this header in translation units guarantees the alias is available
+// everywhere without having to refactor every single source file at once.
+namespace legged
+{
+// Intentionally empty – this forward declaration ensures the namespace exists
+// before we create an alias for it below. The actual definitions remain in the
+// original headers spread across the project.
+}  // namespace legged
+
+namespace ludan = legged;
+

--- a/src/legged_examples/legged_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/legged_dm_hw/src/DmHW.cpp
@@ -6,7 +6,8 @@
 
 #include <fstream>
 #include <iostream>
-#include <XmlRpcValue.h>
+#include <xmlrpcpp/XmlRpcException.h>
+#include <xmlrpcpp/XmlRpcValue.h>
 
 namespace legged
 {
@@ -251,9 +252,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
       {
         enabled = static_cast<bool>(module["enabled"]);
       }
-      catch (const XmlRpc::XmlRpcException&)
+      catch (const XmlRpc::XmlRpcException& ex)
       {
-        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true.", i);
+        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true. Error: %s", i, ex.getMessage().c_str());
       }
     }
     if (!enabled)
@@ -289,9 +290,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
           {
             moduleDirections.push_back(static_cast<int>(dir_list[j]));
           }
-          catch (const XmlRpc::XmlRpcException&)
+          catch (const XmlRpc::XmlRpcException& ex)
           {
-            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1.", i, j);
+            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1. Error: %s", i, j, ex.getMessage().c_str());
             moduleDirections.push_back(1);
           }
         }
@@ -316,9 +317,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
           directions.push_back(1);
         }
       }
-      catch (const XmlRpc::XmlRpcException&)
+      catch (const XmlRpc::XmlRpcException& ex)
       {
-        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry.", i, j);
+        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry. Error: %s", i, j, ex.getMessage().c_str());
       }
     }
   }
@@ -349,8 +350,8 @@ void DmHW::hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg)
 {
   if (msg->data.size() != 5 * numJoints_) {
     ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%zupos+%zuvel+%zukp+%zukd+%zutau)，当前=%zu",
-                    5ull * numJoints_, numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
-                    msg->data.size());
+                      static_cast<size_t>(5 * numJoints_), numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
+                      msg->data.size());
     return;
   }
   std::lock_guard<std::mutex> lk(cmd_mtx_);

--- a/src/legged_examples/legged_dm_hw/src/legged_dm_hw.cpp
+++ b/src/legged_examples/legged_dm_hw/src/legged_dm_hw.cpp
@@ -62,11 +62,11 @@ int main(int argc, char** argv)
 
   try
   {
-    std::shared_ptr<legged::DmHW> legged_dm_hw = std::make_shared<legged::DmHW>();
+    std::shared_ptr<ludan::DmHW> hardware = std::make_shared<ludan::DmHW>();
 
-    legged_dm_hw->init(nh, robot_hw_nh);
+    hardware->init(nh, robot_hw_nh);
 
-    legged::LeggedHWLoop control_loop(nh, legged_dm_hw);
+    ludan::LeggedHWLoop control_loop(nh, hardware);
 
     ros::waitForShutdown();
   }

--- a/src/legged_examples/neck_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/neck_dm_hw/src/DmHW.cpp
@@ -7,7 +7,8 @@
 #include <fstream>
 #include <iostream>
 #include <sstream>
-#include <XmlRpcValue.h>
+#include <xmlrpcpp/XmlRpcException.h>
+#include <xmlrpcpp/XmlRpcValue.h>
 
 namespace legged
 {
@@ -258,9 +259,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
       {
         enabled = static_cast<bool>(module["enabled"]);
       }
-      catch (const XmlRpc::XmlRpcException&)
+      catch (const XmlRpc::XmlRpcException& ex)
       {
-        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true.", i);
+        ROS_WARN("[DmHW] joint_modules[%d].enabled is not boolean, defaulting to true. Error: %s", i, ex.getMessage().c_str());
       }
     }
     if (!enabled)
@@ -296,9 +297,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
           {
             moduleDirections.push_back(static_cast<int>(dir_list[j]));
           }
-          catch (const XmlRpc::XmlRpcException&)
+          catch (const XmlRpc::XmlRpcException& ex)
           {
-            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1.", i, j);
+            ROS_WARN("[DmHW] joint_modules[%d].directions[%d] not integer, using 1. Error: %s", i, j, ex.getMessage().c_str());
             moduleDirections.push_back(1);
           }
         }
@@ -323,9 +324,9 @@ bool DmHW::flattenJointModules(const ros::NodeHandle& robot_hw_nh,
           directions.push_back(1);
         }
       }
-      catch (const XmlRpc::XmlRpcException&)
+      catch (const XmlRpc::XmlRpcException& ex)
       {
-        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry.", i, j);
+        ROS_WARN("[DmHW] joint_modules[%d].joints[%d] not a string, skipping entry. Error: %s", i, j, ex.getMessage().c_str());
       }
     }
   }
@@ -445,8 +446,8 @@ void DmHW::hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg)
 {
   if (msg->data.size() != 5 * numJoints_) {
     ROS_WARN_THROTTLE(1.0, "[DmHW] /hybrid_cmd 长度应为%zu(%zupos+%zuvel+%zukp+%zukd+%zutau)，当前=%zu",
-                    5ull * numJoints_, numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
-                    msg->data.size());
+                      static_cast<size_t>(5 * numJoints_), numJoints_, numJoints_, numJoints_, numJoints_, numJoints_,
+                      msg->data.size());
     return;
   }
   std::lock_guard<std::mutex> lk(cmd_mtx_);

--- a/src/legged_examples/neck_dm_hw/src/legged_dm_hw.cpp
+++ b/src/legged_examples/neck_dm_hw/src/legged_dm_hw.cpp
@@ -62,11 +62,11 @@ int main(int argc, char** argv)
 
   try
   {
-    std::shared_ptr<legged::DmHW> legged_dm_hw = std::make_shared<legged::DmHW>();
+    std::shared_ptr<ludan::DmHW> hardware = std::make_shared<ludan::DmHW>();
 
-    legged_dm_hw->init(nh, robot_hw_nh);
+    hardware->init(nh, robot_hw_nh);
 
-    legged::LeggedHWLoop control_loop(nh, legged_dm_hw);
+    ludan::LeggedHWLoop control_loop(nh, hardware);
 
     ros::waitForShutdown();
   }

--- a/src/legged_hw/include/legged_hw/LeggedHW.h
+++ b/src/legged_hw/include/legged_hw/LeggedHW.h
@@ -26,6 +26,7 @@ at www.bridgedp.com.
 #include <hardware_interface/robot_hw.h>
 #include <legged_common/hardware_interface/ContactSensorInterface.h>
 #include <legged_common/hardware_interface/HybridJointInterface.h>
+#include <legged_common/namespaces.h>
 #include <dmbot_serial/robot_connect.h>
 //#include <dmbot_serial/robot3.h>
 // #include <ahrs_driver.h>


### PR DESCRIPTION
## Summary
- add a shared namespace alias so the ludan robot name can be used alongside the existing legged implementation
- include the XmlRpc++ exception headers and enrich error handling when parsing joint module parameters
- adjust entry points to use the new ludan namespace alias while keeping the existing legged infrastructure intact

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d63f989fc08323b6f570e96abac22f