### PR TITLE
Fix xacro optional argument handling

### DIFF
--- a/src/wanren_arm/urdf/wanren_arm.urdf
+++ b/src/wanren_arm/urdf/wanren_arm.urdf
@@ -9,24 +9,15 @@
   <xacro:arg name="enable_leg_left" default="true" />
   <xacro:arg name="enable_leg_right" default="true" />
 
-  <!-- Normalize optional boolean arguments to safe defaults.
-       "locals().get" allows the file to be processed even when the
-       argument is not provided by older xacro versions that do not
-       implicitly register <xacro:arg> values. -->
-  <xacro:property name="enable_waist_arg" value="${locals().get('enable_waist', 'true')}" />
-  <xacro:property name="enable_waist" value="${str(enable_waist_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_neck_left_arg" value="${locals().get('enable_neck_left', 'true')}" />
-  <xacro:property name="enable_neck_left" value="${str(enable_neck_left_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_neck_right_arg" value="${locals().get('enable_neck_right', 'true')}" />
-  <xacro:property name="enable_neck_right" value="${str(enable_neck_right_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_arm_left_arg" value="${locals().get('enable_arm_left', 'true')}" />
-  <xacro:property name="enable_arm_left" value="${str(enable_arm_left_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_arm_right_arg" value="${locals().get('enable_arm_right', 'true')}" />
-  <xacro:property name="enable_arm_right" value="${str(enable_arm_right_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_leg_left_arg" value="${locals().get('enable_leg_left', 'true')}" />
-  <xacro:property name="enable_leg_left" value="${str(enable_leg_left_arg).lower() in ['1', 'true', 'yes']}" />
-  <xacro:property name="enable_leg_right_arg" value="${locals().get('enable_leg_right', 'true')}" />
-  <xacro:property name="enable_leg_right" value="${str(enable_leg_right_arg).lower() in ['1', 'true', 'yes']}" />
+  <!-- Normalize optional boolean arguments to safe defaults using
+       xacro's built-in helpers. -->
+  <xacro:property name="enable_waist" value="${xacro.str_to_bool(enable_waist)}" />
+  <xacro:property name="enable_neck_left" value="${xacro.str_to_bool(enable_neck_left)}" />
+  <xacro:property name="enable_neck_right" value="${xacro.str_to_bool(enable_neck_right)}" />
+  <xacro:property name="enable_arm_left" value="${xacro.str_to_bool(enable_arm_left)}" />
+  <xacro:property name="enable_arm_right" value="${xacro.str_to_bool(enable_arm_right)}" />
+  <xacro:property name="enable_leg_left" value="${xacro.str_to_bool(enable_leg_left)}" />
+  <xacro:property name="enable_leg_right" value="${xacro.str_to_bool(enable_leg_right)}" />
 
   <!-- Base reference link -->
   <link name="base_link">


### PR DESCRIPTION
## Summary
- replace deprecated locals() usage in wanren_arm xacro with xacro.str_to_bool helpers
- ensure optional argument defaults resolve without runtime errors on newer xacro releases

## Testing
- ⚠️ `xacro src/wanren_arm/urdf/wanren_arm.urdf robot_type:=dm` *(fails: xacro command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d649a521d08323826f676472b0c8c0