### PR TITLE
Prevent startup motor motion by initializing command buffers

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -8,6 +8,14 @@
 
 该程序是基于[livelybot_dynamic_control](https://github.com/HighTorque-Robotics/livelybot_dynamic_control)、[hunter_bipedal_control](https://bridgedp.github.io/hunter_bipedal_control)以及[legged_control](https://github.com/qiayuanl/legged_control)上进行一些改进，主要是对**约束**进行了修改。
 
+### 启动阶段电机控制逻辑定位
+
+为了避免系统上电后立即向电机发送非零指令，`legged_examples/*/DmHW.cpp` 中的 `DmHW::read()` 会在第一次读取到电机状态时，将 `jointData_` 的目标位姿与力矩缓存初始化为当前位置和零增量，再允许后续控制器写入新的命令。
+
+- 全身：`src/legged_examples/legged_dm_hw/src/DmHW.cpp`
+- 左臂：`src/legged_examples/leftarm_dm_hw/src/DmHW.cpp`
+- 脖子：`src/legged_examples/neck_dm_hw/src/DmHW.cpp`
+
 ## 学习
 1. 理论框架
 

--- a/src/legged_examples/leftarm_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/leftarm_dm_hw/src/DmHW.cpp
@@ -80,6 +80,20 @@ void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
     jointData_[i].tau_ = tau * directionMotor_[i];
   }
 
+  if (!commandsInitialized_)
+  {
+    for (int i = 0; i < NUM_JOINTS; ++i)
+    {
+      jointData_[i].pos_des_ = jointData_[i].pos_;
+      jointData_[i].vel_des_ = 0.0;
+      jointData_[i].kp_      = 0.0;
+      jointData_[i].kd_      = 0.0;
+      jointData_[i].ff_      = 0.0;
+    }
+    commandsInitialized_ = true;
+    ROS_INFO("[LeftArm DmHW] Initialized command buffer with current joint states.");
+  }
+
   // IMU 直接用外部 /imu/data
   imuData_.ori[0] = yesenceIMU_.orientation.x;
   imuData_.ori[1] = yesenceIMU_.orientation.y;

--- a/src/legged_examples/legged_dm_hw/include/legged_dm_hw/DmHW.h
+++ b/src/legged_examples/legged_dm_hw/include/legged_dm_hw/DmHW.h
@@ -69,6 +69,7 @@ private:
   int powerLimit_{0};
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
+  bool commandsInitialized_{false};
 
   // 下发缓冲（电机方向映射）
   DmMotorData dmSendcmd_[NUM_JOINTS];

--- a/src/legged_examples/legged_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/legged_dm_hw/src/DmHW.cpp
@@ -68,6 +68,20 @@ void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
     jointData_[i].tau_ = tau * directionMotor_[i];
   }
 
+  if (!commandsInitialized_)
+  {
+    for (int i = 0; i < NUM_JOINTS; ++i)
+    {
+      jointData_[i].pos_des_ = jointData_[i].pos_;
+      jointData_[i].vel_des_ = 0.0;
+      jointData_[i].kp_      = 0.0;
+      jointData_[i].kd_      = 0.0;
+      jointData_[i].ff_      = 0.0;
+    }
+    commandsInitialized_ = true;
+    ROS_INFO("[Legged DmHW] Initialized command buffer with current joint states.");
+  }
+
   // IMU 直接用外部 /imu/data
   imuData_.ori[0] = yesenceIMU_.orientation.x;
   imuData_.ori[1] = yesenceIMU_.orientation.y;

--- a/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
+++ b/src/legged_examples/neck_dm_hw/include/neck_dm_hw/DmHW.h
@@ -74,6 +74,7 @@ private:
   int powerLimit_{0};
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
+  bool commandsInitialized_{false};
 
   std::array<int, NUM_JOINTS> motorIdMap_{};
 

--- a/src/legged_examples/neck_dm_hw/src/DmHW.cpp
+++ b/src/legged_examples/neck_dm_hw/src/DmHW.cpp
@@ -80,6 +80,20 @@ void DmHW::read(const ros::Time & /*time*/, const ros::Duration & /*period*/)
     jointData_[i].tau_ = tau * directionMotor_[i];
   }
 
+  if (!commandsInitialized_)
+  {
+    for (int i = 0; i < NUM_JOINTS; ++i)
+    {
+      jointData_[i].pos_des_ = jointData_[i].pos_;
+      jointData_[i].vel_des_ = 0.0;
+      jointData_[i].kp_      = 0.0;
+      jointData_[i].kd_      = 0.0;
+      jointData_[i].ff_      = 0.0;
+    }
+    commandsInitialized_ = true;
+    ROS_INFO("[Neck DmHW] Initialized command buffer with current joint states.");
+  }
+
   // IMU 直接用外部 /imu/data
   imuData_.ori[0] = yesenceIMU_.orientation.x;
   imuData_.ori[1] = yesenceIMU_.orientation.y;


### PR DESCRIPTION
## Summary
- initialize the DmHW read loop to seed desired joint targets with the measured positions on the first cycle so motors stay idle at startup
- document where the startup motor command logic lives for the full body, left arm, and neck hardware drivers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68d64d1193ac8323be32a70befe42af3