### PR TITLE
Fix command initialization flag in left arm hardware

### DIFF
--- a/src/legged_examples/leftarm_dm_hw/include/neck_dm_hw/DmHW.h
+++ b/src/legged_examples/leftarm_dm_hw/include/neck_dm_hw/DmHW.h
@@ -98,6 +98,7 @@ private:
   bool emergency_stop_{false};
   bool manual_override_{false};
   double manual_cmd_timeout_{0.2};  // 秒
+  bool commandsInitialized_{false};
 };
 
 } // namespace legged


### PR DESCRIPTION
## Summary
- add the missing commandsInitialized_ flag to the left arm hardware interface

## Testing
- not run (catkin CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d6568a12ec8323ba35429235cd967b