### PR TITLE
Add motor ID remapping support to leg DM hardware

### DIFF
--- a/src/legged_examples/legged_dm_hw/config/dm.yaml
+++ b/src/legged_examples/legged_dm_hw/config/dm.yaml
@@ -4,4 +4,6 @@ legged_dm_hw:
   thread_priority: 95
   power_limit: 6
   contact_threshold: 200
+  # 关节索引 -> 实际电机 CAN ID 映射（-1 表示禁用该关节）。默认保持 0..13 顺序，可按需修改。
+  motor_id_map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]
 

--- a/src/legged_examples/legged_dm_hw/include/legged_dm_hw/DmHW.h
+++ b/src/legged_examples/legged_dm_hw/include/legged_dm_hw/DmHW.h
@@ -13,6 +13,7 @@
 
 #include <memory>
 static constexpr int NUM_JOINTS = 14;
+static constexpr int kInvalidMotor = -1;
 namespace legged
 {
 
@@ -58,6 +59,9 @@ private:
   void hybridCmdCb(const std_msgs::Float64MultiArray::ConstPtr& msg);
   void emgCb(const std_msgs::Float32::ConstPtr& msg);
 
+  // 关节到电机 ID 映射
+  void loadMotorIdMap(const ros::NodeHandle& robot_hw_nh);
+
   // 发布/订阅器
   ros::Publisher cmd_pos_pub_, cmd_vel_pub_, cmd_ff_pub_, read_pos_pub_, read_vel_pub_, read_ff_pub_;
   ros::Subscriber odom_sub_;
@@ -70,6 +74,8 @@ private:
   int contactThreshold_{0};
   bool estimateContact_[4]{false, false, false, false};
   bool commandsInitialized_{false};
+
+  std::array<int, NUM_JOINTS> motorIdMap_{};
 
   // 下发缓冲（电机方向映射）
   DmMotorData dmSendcmd_[NUM_JOINTS];


### PR DESCRIPTION
## Summary
- allow leg DmHW to load a motor_id_map parameter just like the neck hardware
- guard command/feedback loops with the mapping so joints can be reordered or disabled safely
- document the new mapping knob in the leg hardware configuration

## Testing
- `catkin_make` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d6599eed0c8323965eb256d416066a